### PR TITLE
docs/ios-highlight-api-key-info

### DIFF
--- a/ui-kit/ios/getting-started.mdx
+++ b/ui-kit/ios/getting-started.mdx
@@ -249,7 +249,7 @@ You can initialize CometChat and log in a user in your `SceneDelegate.swift` fil
 
 > ⚠️ **Important:** Initialization and login are independent steps. However, the CometChat SDK **must be initialized before** you call the login method.
 
-```swift SceneDelegate.swift
+```swift SceneDelegate.swift highlight={13-15} lines
 import UIKit
 import CometChatUIKitSwift
 

--- a/ui-kit/ios/ios-conversation.mdx
+++ b/ui-kit/ios/ios-conversation.mdx
@@ -27,7 +27,7 @@ The **Conversation List + Message View** layout offers a modern two-panel chat e
 
 Ensure UIKit is initialized and the user is logged in before presenting the conversation view.
 
-```swift SceneDelegate.swift
+```swift SceneDelegate.swift highlight={15-17} lines
 import UIKit
 import CometChatUIKitSwift
 import CometChatSDK
@@ -101,7 +101,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 This view controller handles chat between users or within groups.
 
-```swift MessagesVC.swift
+```swift MessagesVC.swift lines
 import UIKit
 import CometChatSDK
 import CometChatUIKitSwift

--- a/ui-kit/ios/ios-one-to-one-chat.mdx
+++ b/ui-kit/ios/ios-one-to-one-chat.mdx
@@ -27,7 +27,7 @@ The **One-to-One Chat** feature provides a streamlined **direct messaging interf
 
 Ensure UI Kit is initialized and the user is logged in before presenting the message view.
 
-```swift SceneDelegate.swift
+```swift SceneDelegate.swift highlight={15-17} lines
 import UIKit
 import CometChatUIKitSwift
 import CometChatSDK
@@ -103,7 +103,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 This view controller handles chat between users or within groups.
 
-```swift MessagesVC.swift
+```swift MessagesVC.swift lines
 import UIKit
 import CometChatSDK
 import CometChatUIKitSwift

--- a/ui-kit/ios/ios-tab-based-chat.mdx
+++ b/ui-kit/ios/ios-tab-based-chat.mdx
@@ -28,7 +28,7 @@ This layout contains:
 
 Ensure UIKit is initialized and the user is logged in before presenting the tabbed view.
 
-```swift SceneDelegate.swift
+```swift SceneDelegate.swift highlight={5-7} lines
 func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
     guard let windowScene = (scene as? UIWindowScene) else { return }
 
@@ -65,7 +65,7 @@ func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options conn
 
 Create a method to display the tab layout.
 
-```swift SceneDelegate.swift
+```swift SceneDelegate.swift lines
 func setupTabbedView(windowScene: UIWindowScene) {
 
     // Create the main Tab Bar Controller
@@ -142,7 +142,7 @@ func setupTabbedView(windowScene: UIWindowScene) {
 
 This view controller handles chat between users or within groups.
 
-```swift MessagesVC.swift
+```swift MessagesVC.swift lines
 import UIKit
 import CometChatSDK
 import CometChatUIKitSwift


### PR DESCRIPTION
## Description

This PR updates the iOS Getting Started documentation by highlighting the lines where developers are expected to input their App ID, Region Code, and Auth Key. This visual enhancement helps reduce confusion and improves onboarding clarity.

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [ ] Documentation correction/update
- [ ] New documentation
- [x] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

- Branch: docs/ios-get-started-highlight-api-info
- Highlighting was added using highlight={} inside code blocks (MDX)
- Add line numbers to code examples to improve readability and make referencing easier.
- Applied to all relevant code blocks within the Getting Started section for iOS


