### PR TITLE
Added the fix for the mark as read with onBehalfOf

### DIFF
--- a/chat-apis.json
+++ b/chat-apis.json
@@ -5000,7 +5000,7 @@
                     {
                         "name": "onBehalfOf",
                         "in": "header",
-                        "description": "UID of the receiver of the message",
+                        "description": "UID of the group member marking the messages as unread.",
                         "required": true,
                         "schema": {
                             "type": "string"


### PR DESCRIPTION
## Description
Mark as unread API for group needs to have onBehalf as required
<!-- Please include a summary of the changes and relevant context. -->

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [ ] Documentation correction/update
- [ ] New documentation
- [x] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [ ] My changes follow the documentation style guide
- [ ] I have checked for spelling and grammar errors
- [ ] All links in my changes are valid and working
- [ ] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
