### PR TITLE
Added Callout for custom text formatters

### DIFF
--- a/ui-kit/react/custom-text-formatter-guide.mdx
+++ b/ui-kit/react/custom-text-formatter-guide.mdx
@@ -14,6 +14,10 @@ You can create your custom text formatter for CometChat using the `CometChatText
 * **Input Field Integration:**: Seamlessly integrates with the text input field, allowing for real-time monitoring and processing of user input for formatting purposes.
 * **Callback Functions:**: Implement callback functions for key up and key down events, providing hooks for custom actions or formatting logic based on user interactions.
 
+<Warning>
+Always wrap formatted data in a span with a unique CSS class (for example, "custom-hashtag"). This lets the UI Kit render it as-is instead of sanitizing it along with other tags.
+</Warning>
+
 ## Usage
 
 here are the steps to create your custom text formatter for CometChat using the `CometChatTextFormatter`:
@@ -40,7 +44,7 @@ class HashTagTextFormatter extends CometChatTextFormatter {
 this.setTrackingCharacter("#");
 this.setRegexPatterns([/\B#(\w+)\b/g]);
 this.setRegexToReplaceFormatting([
-  /<span style="color: #30b3ff;">#(\w+)<\/span>/g,
+  /<span class="custom-hashtag" style="color: #30b3ff;">#(\w+)<\/span>/g,
 ]);
 ```
 
@@ -195,7 +199,7 @@ class HashTagTextFormatter extends CometChatTextFormatter {
     // Replace hashtags with HTML span elements to change color to green
     return inputText.replace(
       /\B#(\w+)\b/g,
-      '<span style="color: #5dff05;">#$1</span>'
+      '<span class="custom-hashtag" style="color: #5dff05;">#$1</span>'
     );
   }
 

--- a/ui-kit/react/v5/custom-text-formatter-guide.mdx
+++ b/ui-kit/react/v5/custom-text-formatter-guide.mdx
@@ -16,6 +16,10 @@ You can create your custom text formatter for CometChat using the `CometChatText
 * **Input Field Integration:**: Seamlessly integrates with the text input field, allowing for real-time monitoring and processing of user input for formatting purposes.
 * **Callback Functions:**: Implement callback functions for key up and key down events, providing hooks for custom actions or formatting logic based on user interactions.
 
+<Warning>
+Always wrap formatted data in a span with a unique CSS class (for example, "custom-hashtag"). This lets the UI Kit render it as-is instead of sanitizing it along with other tags.
+</Warning>
+
 ## Usage
 
 here are the steps to create your custom text formatter for CometChat using the `CometChatTextFormatter`:
@@ -42,7 +46,7 @@ class HashTagTextFormatter extends CometChatTextFormatter {
 this.setTrackingCharacter("#");
 this.setRegexPatterns([/\B#(\w+)\b/g]);
 this.setRegexToReplaceFormatting([
-  /<span style="color: #30b3ff;">#(\w+)<\/span>/g,
+  /<span class="custom-hashtag" style="color: #30b3ff;">#(\w+)<\/span>/g,
 ]);
 ```
 
@@ -197,7 +201,7 @@ class HashTagTextFormatter extends CometChatTextFormatter {
     // Replace hashtags with HTML span elements to change color to green
     return inputText.replace(
       /\B#(\w+)\b/g,
-      '<span style="color: #5dff05;">#$1</span>'
+      '<span class="custom-hashtag" style="color: #5dff05;">#$1</span>'
     );
   }
 


### PR DESCRIPTION
## Description

<!-- Please include a summary of the changes and relevant context. -->
- Added the custom formatter callout text for React v5 & v6 UIKit to always pass a className with HTML tags.
## Related Issue(s)
NA
<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [x] Documentation correction/update
- [ ] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
