### PR TITLE
Corrected prodocs links

### DIFF
--- a/chat-apis.json
+++ b/chat-apis.json
@@ -375,7 +375,7 @@
                                 ],
                                 "properties": {
                                     "uid": {
-                                        "description": "Unique identifier of the user. Please refer to https://prodocs.cometchat.com/docs/concepts#uid",
+                                        "description": "Unique identifier of the user. Please refer to https://www.cometchat.com/docs/rest-api/users",
                                         "type": "string"
                                     },
                                     "name": {

--- a/sdk/ionic-legacy/2.0/bots.mdx
+++ b/sdk/ionic-legacy/2.0/bots.mdx
@@ -22,4 +22,4 @@ Once you've created a user, you can create a new bot. The actual implementation 
 
 ### Reply to a message
 
-When you receive a message from CometChat, you can process it and provide a response using our [Send Bot Message](https://prodocs.cometchat.com/reference#send-bot-message) Rest API.
+When you receive a message from CometChat, you can process it and provide a response using our [Send Bot Message](https://www.cometchat.com/docs/rest-api/messages/send-bot-message) Rest API.

--- a/ui-kit/android/v2/overview.mdx
+++ b/ui-kit/android/v2/overview.mdx
@@ -213,7 +213,7 @@ To integrate the UI Kit, please follow the steps below:
 
 [Download UI Kit Library](https://github.com/cometchat-pro/android-java-chat-ui-kit/archive/v2.zip)
 
-* Import `uikit` Module from Module Settings.( To know how to import `uikit` as Module visit this [link](https://prodocs.cometchat.com/docs/android-ui-kit-setup) )
+* Import `uikit` Module from Module Settings.( To know how to import `uikit` as Module visit this [link](https://www.cometchat.com/docs/ui-kit/android/v2/overview#setup-) )
 * If the Library is added sucessfully, it will look like mentioned in the below image.
 
 <Frame>


### PR DESCRIPTION
## Description

The docs had old prodocs.cometchat.com links

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->
None

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [x] Documentation correction/update
- [ ] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
