### PR TITLE
feat(notifications): add poll and reminder push notification templates

### DIFF
--- a/chat-apis.json
+++ b/chat-apis.json
@@ -9577,6 +9577,30 @@
                                                 "body_image": "New image message",
                                                 "body_video": "New video message"
                                             },
+                                            "pollMessageTemplateDefault": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "pollMessageTemplatePrivacy": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "reminderMessageTemplateDefault": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "reminderMessageTemplatePrivacy": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
                                             "customMessageTemplateDefault": {
                                                 "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
                                                 "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
@@ -10332,6 +10356,30 @@
                                                 "body_image": "New message",
                                                 "body_video": "New message"
                                             },
+                                            "pollMessageTemplateDefault": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "pollMessageTemplatePrivacy": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "reminderMessageTemplateDefault": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "reminderMessageTemplatePrivacy": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
                                             "customMessageTemplateDefault": {
                                                 "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
                                                 "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
@@ -10544,6 +10592,30 @@
                                                 "body_file": "New message",
                                                 "body_image": "New message",
                                                 "body_video": "New message"
+                                            },
+                                            "pollMessageTemplateDefault": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "pollMessageTemplatePrivacy": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "reminderMessageTemplateDefault": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
+                                            },
+                                            "reminderMessageTemplatePrivacy": {
+                                                "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
+                                                "titleGroup": "{{message.data.entities.sender.entity.name}} @ {{message.data.entities.receiver.entity.name}}",
+                                                "body": "{{message.data.text}}",
+                                                "body_fallback": ""
                                             },
                                             "customMessageTemplateDefault": {
                                                 "titleOneOnOne": "{{message.data.entities.sender.entity.name}}",
@@ -16921,6 +16993,70 @@
                     },
                     "mediaMessageTemplatePrivacy": {
                         "$ref": "#/components/schemas/MediaMessageTemplate"
+                    },
+                    "pollMessageTemplateDefault": {
+                        "description": "Default template for poll messages (category: custom, type: extension_poll).",
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "body_fallback": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "$ref": "#/components/schemas/Template"
+                            }
+                        ]
+                    },
+                    "pollMessageTemplatePrivacy": {
+                        "description": "Privacy template for poll messages (category: custom, type: extension_poll).",
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "body_fallback": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "$ref": "#/components/schemas/Template"
+                            }
+                        ]
+                    },
+                    "reminderMessageTemplateDefault": {
+                        "description": "Default template for reminder messages (category: custom, type: extension_reminders).",
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "body_fallback": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "$ref": "#/components/schemas/Template"
+                            }
+                        ]
+                    },
+                    "reminderMessageTemplatePrivacy": {
+                        "description": "Privacy template for reminder messages (category: custom, type: extension_reminders).",
+                        "allOf": [
+                            {
+                                "properties": {
+                                    "body_fallback": {
+                                        "type": "string"
+                                    }
+                                },
+                                "type": "object"
+                            },
+                            {
+                                "$ref": "#/components/schemas/Template"
+                            }
+                        ]
                     },
                     "customMessageTemplateDefault": {
                         "allOf": [


### PR DESCRIPTION
Add pollMessageTemplate and reminderMessageTemplate (Default + Privacy) to the Templates schema and all response examples in chat-apis.json. Templates are placed before customMessageTemplates as specified.

## Description

<!-- Please include a summary of the changes and relevant context. -->

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [x] Documentation correction/update
- [ ] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [ ] My changes follow the documentation style guide
- [ ] I have checked for spelling and grammar errors
- [ ] All links in my changes are valid and working
- [ ] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
