### PR TITLE
docs: Add aiAssistantTools and autoOpenFirstItem widget config props

### DIFF
--- a/ai-agents/chat-widget.mdx
+++ b/ai-agents/chat-widget.mdx
@@ -75,6 +75,18 @@ Choose the auth flow that matches your site:
     defaultChatID: "<YOUR_AGENT_ID>",  // point to your AI agent
     variantID: "<YOUR_VARIANT_ID>",
     //dockedAlignment: "left" | "right"
+
+    // Define your tools here
+    aiAssistantTools: {
+      getCurrentWeather: ({ location }) => {
+        // Call your weather API, or return mock data
+        return `The weather in ${location} is 25°C and sunny.`;
+      },
+      createTicket: ({ title }) => {
+        // Call your ticketing system, or return a confirmation
+        return `Ticket "${title}" created successfully with ID #12345.`;
+      },
+    },
   };
 
   CometChatApp.CometChatAuth.start(COMETCHAT_WIDGET_CONFIG);
@@ -118,6 +130,18 @@ Choose the auth flow that matches your site:
     defaultChatID: "<YOUR_AGENT_ID>",  // open AI agent by default
     variantID: "<YOUR_VARIANT_ID>",
     //dockedAlignment: "left" | "right"
+
+    // Define your tools here
+    aiAssistantTools: {
+      getCurrentWeather: ({ location }) => {
+        // Call your weather API, or return mock data
+        return `The weather in ${location} is 25°C and sunny.`;
+      },
+      createTicket: ({ title }) => {
+        // Call your ticketing system, or return a confirmation
+        return `Ticket "${title}" created successfully with ID #12345.`;
+      },
+    },
   };
 
   CometChatApp.CometChatAuth.start(COMETCHAT_WIDGET_CONFIG);
@@ -153,6 +177,18 @@ Choose the auth flow that matches your site:
     defaultChatID: "<YOUR_AGENT_ID>",   // open AI agent by default
     variantID: "<YOUR_VARIANT_ID>",
     //dockedAlignment: "left" | "right"
+
+    // Define your tools here
+    aiAssistantTools: {
+      getCurrentWeather: ({ location }) => {
+        // Call your weather API, or return mock data
+        return `The weather in ${location} is 25°C and sunny.`;
+      },
+      createTicket: ({ title }) => {
+        // Call your ticketing system, or return a confirmation
+        return `Ticket "${title}" created successfully with ID #12345.`;
+      },
+    },
   };
 
   CometChatApp.CometChatAuth.start(COMETCHAT_WIDGET_CONFIG);

--- a/widget/html/integration.mdx
+++ b/widget/html/integration.mdx
@@ -70,6 +70,7 @@ Add the CometChat Widget by pasting one small HTML snippet. It drops in like any
     //chatType: "user" | "group",
     //defaultChatID: "uid_or_guid",
     //dockedAlignment: "left" | "right"
+    //autoOpenFirstItem: false,
   };
 
   CometChatApp.CometChatAuth.start(COMETCHAT_WIDGET_CONFIG);
@@ -87,6 +88,7 @@ Add the CometChat Widget by pasting one small HTML snippet. It drops in like any
 | `chatType` | Determines the type of conversation the widget initiates by default (one-on-one user chat or a group chat). |
 | `defaultChatID` | The specific chat with user (`uid`) or group (`guid`) that should automatically open when the widget loads. |
 | `dockedAlignment` | Controls the position of the docked widget interface on the page (left side or right side). |
+| `autoOpenFirstItem` | When set to `false`, the widget does not automatically open the first conversation on load. Defaults to `true`. |
 
 ## 2. Create + Log In User On The Fly
 
@@ -135,6 +137,7 @@ Add the CometChat Widget by pasting one small HTML snippet. It drops in like any
     //chatType: "user" | "group",
     //defaultChatID: "uid_or_guid",
     //dockedAlignment: "left" | "right"
+    //autoOpenFirstItem: false,
   };
 
   CometChatApp.CometChatAuth.start(COMETCHAT_WIDGET_CONFIG);
@@ -154,6 +157,7 @@ Add the CometChat Widget by pasting one small HTML snippet. It drops in like any
 | `chatType` | Determines the type of conversation the widget initiates by default (one-on-one user chat or a group chat). |
 | `defaultChatID` | The specific chat with user (`uid`) or group (`guid`) that should automatically open when the widget loads. |
 | `dockedAlignment` | Controls the position of the docked widget interface on the page (left side or right side). |
+| `autoOpenFirstItem` | When set to `false`, the widget does not automatically open the first conversation on load. Defaults to `true`. |
 
 ## 3. Backend-Created User (Auth Token Login)
 
@@ -202,6 +206,7 @@ Full walkthrough: [How to properly log in and create users in CometChat](https:/
     //chatType: "user" | "group",
     //defaultChatID: "uid_or_guid",
     //dockedAlignment: "left" | "right"
+    //autoOpenFirstItem: false,
   };
 
   CometChatApp.CometChatAuth.start(COMETCHAT_WIDGET_CONFIG);
@@ -220,3 +225,4 @@ Full walkthrough: [How to properly log in and create users in CometChat](https:/
 | `chatType` | Determines the type of conversation the widget initiates by default (one-on-one user chat or a group chat). |
 | `defaultChatID` | The specific chat with user (`uid`) or group (`guid`) that should automatically open when the widget loads. |
 | `dockedAlignment` | Controls the position of the docked widget interface on the page (left side or right side). |
+| `autoOpenFirstItem` | When set to `false`, the widget does not automatically open the first conversation on load. Defaults to `true`. |


### PR DESCRIPTION
## Summary

Adds documentation for two new Chat Widget configuration properties: `aiAssistantTools` and `autoOpenFirstItem`.

## Changes

### `ai-agents/chat-widget.mdx`
- Added `aiAssistantTools` prop to all three auth flow examples (Guest, UID, Auth Token).
- Includes example tool definitions (`getCurrentWeather`, `createTicket`) showing how to wire up client-side tool handlers that the AI agent can invoke.

### `widget/html/integration.mdx`
- Added `autoOpenFirstItem` as a commented-out optional prop in all three auth flow code blocks (Guest, UID, Auth Token).
- Added `autoOpenFirstItem` row to each "Update these values" settings table with description: when set to `false`, the widget does not automatically open the first conversation on load (defaults to `true`).

## Testing
- Verified the Mintlify dev preview renders all updated code blocks and tables correctly.
