### PR TITLE
fix: remove line break in Calls API base URL

### DIFF
--- a/articles/error-guide.mdx
+++ b/articles/error-guide.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Error Guide"
 sidebarTitle: "Error Codes"
-description: "Error Guide — CometChat integration guide."
+description: "Common error codes and their descriptions for CometChat REST APIs."
 ---
 
 | Error Code                          | Error Description                                                                                                                                                                                   |

--- a/articles/migration-guide.mdx
+++ b/articles/migration-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Migration Guide"
-description: "Migration Guide — CometChat integration guide."
+description: "Step-by-step guide to migrate your application from CometChat v2 to v3."
 ---
 
 This guide will help you upgrade your application(s) and platform(s) from CometChat v2 to v3. The upgrade process is simple, since there only a few code-level changes required.
@@ -59,9 +59,9 @@ React Native: [Upgrading from v2](/sdk/react-native/3.0/resources-upgrading-from
 
 Ionic Cordova Capacitor: [Upgrading from v2](/sdk/ionic-legacy/3.0/resources-upgrading-from-v2)
 
-*Note: if you mark your migration as complete without following the specified upgrade guide fully, your application may become stuck in a broken state, with out-of-sync SDK / API and application versions unable to communicate properly. If this happens, contact support.*
+_Note: if you mark your migration as complete without following the specified upgrade guide fully, your application may become stuck in a broken state, with out-of-sync SDK / API and application versions unable to communicate properly. If this happens, contact support._
 
-## Rest API Changes 
+## Rest API Changes
 
 This step is only applicable if you are using CometChat Rest APIs. Go to [Rest API documentation](/rest-api/chat-apis) Make sure you have selected V3. Select and update the API URLs applicable to your implementation.
 
@@ -82,7 +82,6 @@ Once all the steps are done you'll be able to see that your app is migrated to v
 ## FAQs
 
 1. What are the **Benefits** of upgrading?
-
    1. **Faster** connection & response times
    2. **Higher** rate limits
    3. Supports up to **100K** users in a group
@@ -93,27 +92,22 @@ Once all the steps are done you'll be able to see that your app is migrated to v
    8. v3 provides you with a stronger infrastructure, scalability, and more feature-based solutions to take your chat to the next level!.
 
 2. What exactly do I need to do, what are the steps?
-
-   * Please refer the [Migration Guide](/articles/migration-guide)
+   - Please refer the [Migration Guide](/articles/migration-guide)
 
 3. How much effort does it take?
 
-4. * Per app just the code changes should not take more than 30 mins.
+4. - Per app just the code changes should not take more than 30 mins.
 
 5. How can I ask for help if I am stuck at some stage?
-
-   * You can reach out to our customer support team for such queries.
+   - You can reach out to our customer support team for such queries.
 
 6. What is the transition time you suggest?
-
-   * It depends on how much time it takes for clients using the old v2 SDK to update to v3 SDK.
+   - It depends on how much time it takes for clients using the old v2 SDK to update to v3 SDK.
 
 7. Will there be any regression during transition?
-
-   * During transition, real-time events (receipts, typing indicator, live reactions, transient messages, and user presence indicators) won’t work cross-version. This means that users with clients using the old v2 SDK won’t get real-time events from users on clients supporting the new v3 SDK, and vice-versa. However, receipts and presence information are still updated in our database, so they'll still be available when fetched via the API.
+   - During transition, real-time events (receipts, typing indicator, live reactions, transient messages, and user presence indicators) won’t work cross-version. This means that users with clients using the old v2 SDK won’t get real-time events from users on clients supporting the new v3 SDK, and vice-versa. However, receipts and presence information are still updated in our database, so they'll still be available when fetched via the API.
 
 8. What all checks do I need to perform before marking V3 complete?
-
    1. Go to the dashboard and make a migration request for your application(s)
    2. [Make any required platform-specific code changes](/articles/migration-guide#migrating-your-platform)
    3. [Make the API changes (Applicable if you are using CometChat Rest APIs)](/rest-api/chat-apis)

--- a/rest-api/authentication.mdx
+++ b/rest-api/authentication.mdx
@@ -7,9 +7,7 @@ description: "How to authenticate REST API requests to CometChat."
 All CometChat REST API requests must be authenticated using an API key passed in the `apikey` HTTP header.
 
 <Note>
-  **Calls APIs** use a different base URL: `https://{appId}.call-{region}
-  .cometchat.io/v3` (note `call-` instead of `api-`). Authentication still uses
-  the `apikey` header.
+  **Calls APIs** use a different base URL: `https://{appId}.call-{region}.cometchat.io/v3` (note `call-` instead of `api-`). Authentication still uses the `apikey` header.
 </Note>
 
 <Note>


### PR DESCRIPTION
Fixes a line break in the Calls API base URL in `rest-api/authentication.mdx` that was rendering as a space: `https://{appId}.call-{region} .cometchat.io/v3` → `https://{appId}.call-{region}.cometchat.io/v3`