### PR TITLE
docs(ENG-35766): add quotedReplies notification preference

### DIFF
--- a/chat-apis.json
+++ b/chat-apis.json
@@ -8739,6 +8739,8 @@
                         "messagesOverride": true,
                         "repliesSetting": 2,
                         "repliesOverride": true,
+                        "quotedRepliesSetting": 2,
+                        "quotedRepliesOverride": true,
                         "messageDeletedSetting": 2,
                         "reactionsSetting": 2,
                         "reactionsOverride": true,
@@ -8779,6 +8781,8 @@
                         "messagesOverride": true,
                         "repliesSetting": 2,
                         "repliesOverride": true,
+                        "quotedRepliesSetting": 2,
+                        "quotedRepliesOverride": true,
                         "messageEditedSetting": 2,
                         "messageDeletedSetting": 2,
                         "reactionsSetting": 2,
@@ -9538,6 +9542,8 @@
                         "messagesOverride": true,
                         "repliesSetting": 2,
                         "repliesOverride": true,
+                        "quotedRepliesSetting": 2,
+                        "quotedRepliesOverride": true,
                         "reactionsSetting": 2,
                         "reactionsOverride": true,
                         "memberLeftSetting": 1,
@@ -9560,6 +9566,8 @@
                         "messagesOverride": true,
                         "repliesSetting": 2,
                         "repliesOverride": true,
+                        "quotedRepliesSetting": 2,
+                        "quotedRepliesOverride": true,
                         "reactionsSetting": 2,
                         "reactionsOverride": true
                       },
@@ -9735,6 +9743,8 @@
                         "messagesOverride": true,
                         "repliesSetting": 2,
                         "repliesOverride": true,
+                        "quotedRepliesSetting": 2,
+                        "quotedRepliesOverride": true,
                         "reactionsSetting": 2,
                         "reactionsOverride": true,
                         "memberLeftSetting": 1,
@@ -9757,6 +9767,8 @@
                         "messagesOverride": true,
                         "repliesSetting": 2,
                         "repliesOverride": true,
+                        "quotedRepliesSetting": 2,
+                        "quotedRepliesOverride": true,
                         "reactionsSetting": 2,
                         "reactionsOverride": true
                       },
@@ -9920,6 +9932,7 @@
                     "groupPreferences": {
                       "groupMessages": 2,
                       "groupReplies": 2,
+                      "groupQuotedReplies": 2,
                       "groupReactions": 2,
                       "groupMemberLeft": 1,
                       "groupMemberAdded": 1,
@@ -9932,6 +9945,7 @@
                     "oneOnOnePreferences": {
                       "oneOnOneMessages": 2,
                       "oneOnOneReplies": 2,
+                      "oneOnOneQuotedReplies": 2,
                       "oneOnOneReactions": 2
                     },
                     "mutePreferences": {
@@ -11962,13 +11976,14 @@
           {
             "name": "reason",
             "in": "query",
-            "description": "Available only when the value of notificationTriggered is false.\nThis contains the reason for not triggering the notification provider.\n\nTo filter logs using reason, use the following values: MESSAGES_PREFERENCE, REPLIES_PREFERENCE, MESSAGE_ACTIONS_PREFERENCE, REACTIONS_PREFERENCE, GROUP_ACTIONS_PREFERENCE, DND_PREFERENCE, MUTE_PREFERENCE, SCHEDULE_PREFERENCE, CALL_PREFERENCE, QUOTA_PREFERENCE, MISSING_EMAIL, MISSING_PHNO, INVALID_PUSH_PROVIDER_ID, TIMED_OUT, NOT_FOUND, TWILIO_CREATE_ERROR.",
+            "description": "Available only when the value of notificationTriggered is false.\nThis contains the reason for not triggering the notification provider.\n\nTo filter logs using reason, use the following values: MESSAGES_PREFERENCE, REPLIES_PREFERENCE, QUOTED_REPLIES_PREFERENCE, MESSAGE_ACTIONS_PREFERENCE, REACTIONS_PREFERENCE, GROUP_ACTIONS_PREFERENCE, DND_PREFERENCE, MUTE_PREFERENCE, SCHEDULE_PREFERENCE, CALL_PREFERENCE, QUOTA_PREFERENCE, MISSING_EMAIL, MISSING_PHNO, INVALID_PUSH_PROVIDER_ID, TIMED_OUT, NOT_FOUND, TWILIO_CREATE_ERROR.",
             "required": false,
             "schema": {
               "type": "string",
               "enum": [
                 "MESSAGES_PREFERENCE",
                 "REPLIES_PREFERENCE",
+                "QUOTED_REPLIES_PREFERENCE",
                 "MESSAGE_ACTIONS_PREFERENCE",
                 "REACTIONS_PREFERENCE",
                 "GROUP_ACTIONS_PREFERENCE",
@@ -15137,6 +15152,18 @@
           "repliesOverride": {
             "type": "boolean"
           },
+          "quotedRepliesSetting": {
+            "description": "1: Don't notify\n2: Notify for all replies\n3: Notify for replies with mentions",
+            "type": "integer",
+            "enum": [
+              1,
+              2,
+              3
+            ]
+          },
+          "quotedRepliesOverride": {
+            "type": "boolean"
+          },
           "reactionsSetting": {
             "description": "1: Don't notify\n2: Notify for reactions received on own messages\n3: Notify for reactions received on all messages",
             "type": "integer",
@@ -17124,6 +17151,18 @@
           "repliesOverride": {
             "type": "boolean"
           },
+          "quotedRepliesSetting": {
+            "description": "1: Don't notify\n2: Notify for all replies\n3: Notify for replies with mentions",
+            "type": "integer",
+            "enum": [
+              1,
+              2,
+              3
+            ]
+          },
+          "quotedRepliesOverride": {
+            "type": "boolean"
+          },
           "reactionsSetting": {
             "description": "1: Don't notify\n2: Notify for reactions received on own messages\n3: Notify for reactions received on all messages",
             "type": "integer",
@@ -17202,6 +17241,15 @@
                 ]
               },
               "groupReplies": {
+                "description": "1: Don't notify\n2: Notify for all replies\n3: Notify for replies with mentions",
+                "type": "integer",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "groupQuotedReplies": {
                 "description": "1: Don't notify\n2: Notify for all replies\n3: Notify for replies with mentions",
                 "type": "integer",
                 "enum": [
@@ -17290,6 +17338,15 @@
                 ]
               },
               "oneOnOneReplies": {
+                "description": "1: Don't notify\n2: Notify for all replies\n3: Notify for replies with mentions",
+                "type": "integer",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ]
+              },
+              "oneOnOneQuotedReplies": {
                 "description": "1: Don't notify\n2: Notify for all replies\n3: Notify for replies with mentions",
                 "type": "integer",
                 "enum": [

--- a/notifications/preferences.mdx
+++ b/notifications/preferences.mdx
@@ -48,6 +48,7 @@ As the name suggests, these preferences help you to configure Notifications for 
 | --------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | Conversations   | New messages                | • Don't notify<br/>• **Notify for all messages (Default)** <br/>• Notify for messages with mentions                                   | • **Yes (Default)**<br/>• No |
 |                 | New replies                 | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions                                     | • **Yes (Default)**<br/>• No |
+|                 | New quoted replies          | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions                                     | • **Yes (Default)**<br/>• No |
 | Message actions | Message is edited           | • Don't notify<br/>• **Notify (Default)**                                                                                        | • Yes<br/>• **No (Default)** |
 |                 | Message is deleted          | • Don't notify<br/>• **Notify (Default)**                                                                                        | • Yes<br/>• **No (Default)** |
 |                 | Message receives a reaction | • Don't notify<br/>• Notify for reactions received on all messages<br/>• **Notify for reactions received on own messages (Default)** | • **Yes (Default)**<br/>• No |
@@ -85,6 +86,7 @@ const groupPreferences = preferences.getGroupPreferences();
 
 const groupMessagesPreference = groupPreferences.getMessagesPreference();
 const groupRepliesPreference = groupPreferences.getRepliesPreference();
+const groupQuotedRepliesPreference = groupPreferences.getQuotedRepliesPreference();
 const groupReactionsPreference = groupPreferences.getReactionsPreference();
 const memberLeftPreference = groupPreferences.getMemberLeftPreference();
 const memberAddedPreference = groupPreferences.getMemberAddedPreference();
@@ -108,6 +110,7 @@ CometChatNotifications.fetchPreferences(new CometChat.CallbackListener<Notificat
 
       MessagesOptions groupMessagesPreference = groupPreferences.getMessagesPreference();
       RepliesOptions groupRepliesPreference = groupPreferences.getRepliesPreference();
+      RepliesOptions groupQuotedRepliesPreference = groupPreferences.getQuotedRepliesPreference();
       ReactionsOptions groupReactionsPreference = groupPreferences.getReactionsPreference();
       MemberActionsOptions memberAddedPreference = groupPreferences.getMemberAddedPreference();
       MemberActionsOptions memberLeftPreference = groupPreferences.getMemberLeftPreference();
@@ -161,6 +164,7 @@ CometChatNotifications.fetchPreferences(
 
       MessagesOptions? messagesPreference = groupPreferences?.messages;
       RepliesOptions? repliesPreference = groupPreferences?.replies;
+      RepliesOptions? quotedRepliesPreference = groupPreferences?.quotedReplies;
       ReactionsOptions? reactionsPreference = groupPreferences?.reactions;
       MemberActionsOptions? memberAddedPreference = groupPreferences?.memberAdded;
       MemberActionsOptions? memberJoinedPreference = groupPreferences?.memberJoined;
@@ -208,6 +212,7 @@ const groupPreferences = new GroupPreferences();
 // Change group preferences
 groupPreferences.setMessagesPreference(MessagesOptions.DONT_SUBSCRIBE);
 groupPreferences.setRepliesPreference(RepliesOptions.DONT_SUBSCRIBE);
+groupPreferences.setQuotedRepliesPreference(RepliesOptions.DONT_SUBSCRIBE);
 groupPreferences.setReactionsPreference(ReactionsOptions.DONT_SUBSCRIBE);
 groupPreferences.setMemberAddedPreference(MemberActionsOptions.SUBSCRIBE);
 groupPreferences.setMemberKickedPreference(MemberActionsOptions.SUBSCRIBE);
@@ -242,6 +247,7 @@ GroupPreferences groupPreferences = new GroupPreferences();
 // Change group preferences
 groupPreferences.setMessagesPreference(MessagesOptions.DONT_SUBSCRIBE);
 groupPreferences.setRepliesPreference(RepliesOptions.DONT_SUBSCRIBE);
+groupPreferences.setQuotedRepliesPreference(RepliesOptions.DONT_SUBSCRIBE);
 groupPreferences.setReactionsPreference(ReactionsOptions.DONT_SUBSCRIBE);
 groupPreferences.setMemberAddedPreference(MemberActionsOptions.SUBSCRIBE);
 groupPreferences.setMemberKickedPreference(MemberActionsOptions.SUBSCRIBE);
@@ -283,6 +289,7 @@ let groupPreferences = CometChatNotifications.GroupPreferences();
 // Change group preferences
 groupPreferences.set(messagesPreference: .DONT_SUBSCRIBE)
 groupPreferences.set(repliesPreference: .DONT_SUBSCRIBE)
+groupPreferences.set(quotedRepliesPreference: .DONT_SUBSCRIBE)
 groupPreferences.set(reactionsPreference: .DONT_SUBSCRIBE)
 
 groupPreferences.set(memberAddedPreference: .SUBSCRIBE)
@@ -316,6 +323,7 @@ NotificationPreferences updatedPreferences = NotificationPreferences();
 GroupPreferences groupPreferences = GroupPreferences(
   messages: MessagesOptions.SUBSCRIBE_TO_MENTIONS,
   replies: RepliesOptions.SUBSCRIBE_TO_ALL,
+  quotedReplies: RepliesOptions.SUBSCRIBE_TO_ALL,
   reactions: ReactionsOptions.SUBSCRIBE_TO_REACTIONS_ON_ALL_MESSAGES,
   memberAdded: MemberActionsOptions.SUBSCRIBE,
   memberJoined: MemberActionsOptions.SUBSCRIBE,
@@ -351,6 +359,7 @@ As the name suggests, these preferences help you to configure Notifications for 
 | --------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | Conversations   | New messages                | • Don't notify<br/>• **Notify for all messages (Default)**<br/>• Notify for messages with mentions                                   | • **Yes (Default)**<br/>• No |
 |                 | New replies                 | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions                                     | • **Yes (Default)**<br/>• No |
+|                 | New quoted replies          | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions                                     | • **Yes (Default)**<br/>• No |
 | Message actions | Message is edited           | • Don't notify<br/>• **Notify (Default)**                                                                                        | • Yes<br/>• **No (Default)** |
 |                 | Message is deleted          | • Don't notify<br/>• **Notify (Default)**                                                                                        | • Yes<br/>• **No (Default)** |
 |                 | Message receives a reaction | • Don't notify<br/>• Notify for reactions received on all messages<br/>• **Notify for reactions received on own messages (Default)** | • **Yes (Default)**<br/>• No |
@@ -379,6 +388,7 @@ const oneOnOnePreferences = preferences.getOneOnOnePreferences();
 
 const oneOnOneMessagesPreference = oneOnOnePreferences.getMessagesPreference();
 const oneOnOneRepliesPreference = oneOnOnePreferences.getRepliesPreference();
+const oneOnOneQuotedRepliesPreference = oneOnOnePreferences.getQuotedRepliesPreference();
 const oneOnOneReactionsPreference =
   oneOnOnePreferences.getReactionsPreference();
 ```
@@ -395,6 +405,7 @@ CometChatNotifications.fetchPreferences(new CometChat.CallbackListener<Notificat
 
       MessagesOptions oneOnOneMessagesPreference = oneOnOnePreferences.getMessagesPreference();
       RepliesOptions oneOnOneRepliesPreference = oneOnOnePreferences.getRepliesPreference();
+      RepliesOptions oneOnOneQuotedRepliesPreference = oneOnOnePreferences.getQuotedRepliesPreference();
       ReactionsOptions oneOnOneReactionsPreference = oneOnOnePreferences.getReactionsPreference();
   }
 
@@ -433,6 +444,7 @@ CometChatNotifications.fetchPreferences(
 
       MessagesOptions? oneOnOneMessagesPreference = oneOnOnePreferences?.messages;
       RepliesOptions? oneOnOneRepliesPreference = oneOnOnePreferences?.replies;
+      RepliesOptions? oneOnOneQuotedRepliesPreference = oneOnOnePreferences?.quotedReplies;
       ReactionsOptions? oneOnOneReactionsPreference = oneOnOnePreferences?.reactions;
     },
     onError: (e) {
@@ -467,6 +479,7 @@ const oneOnOnePreferences = new OneOnOnePreferences();
 // Change one-on-one preferences
 oneOnOnePreferences.setMessagesPreference(MessagesOptions.DONT_SUBSCRIBE);
 oneOnOnePreferences.setRepliesPreference(RepliesOptions.DONT_SUBSCRIBE);
+oneOnOnePreferences.setQuotedRepliesPreference(RepliesOptions.DONT_SUBSCRIBE);
 oneOnOnePreferences.setReactionsPreference(ReactionsOptions.DONT_SUBSCRIBE);
 
 // Load the updates in the NotificationPreferences instance.
@@ -492,6 +505,7 @@ OneOnOnePreferences oneOnOnePreferences = new OneOnOnePreferences();
 // Change one-on-one preferences
 oneOnOnePreferences.setMessagesPreference(MessagesOptions.DONT_SUBSCRIBE);
 oneOnOnePreferences.setRepliesPreference(RepliesOptions.DONT_SUBSCRIBE);
+oneOnOnePreferences.setQuotedRepliesPreference(RepliesOptions.DONT_SUBSCRIBE);
 oneOnOnePreferences.setReactionsPreference(ReactionsOptions.DONT_SUBSCRIBE);
 
 // Load the updates in the NotificationPreferences instance.
@@ -526,6 +540,7 @@ let oneOnOnePreferences = CometChatNotifications.OneOnOnePreferences();
 // Change one-on-one preferences
 oneOnOnePreferences.set(messagesPreference: .DONT_SUBSCRIBE)
 oneOnOnePreferences.set(repliesPreference: .DONT_SUBSCRIBE)
+oneOnOnePreferences.set(quotedRepliesPreference: .DONT_SUBSCRIBE)
 oneOnOnePreferences.set(reactionsPreference: .DONT_SUBSCRIBE)
 
 // Load the updates in the NotificationPreferences instance.
@@ -552,6 +567,7 @@ NotificationPreferences updatedPreferences = NotificationPreferences();
 OneOnOnePreferences oneOnOnePreferences = OneOnOnePreferences(
   messages: MessagesOptions.SUBSCRIBE_TO_ALL,
   replies: RepliesOptions.SUBSCRIBE_TO_MENTIONS,
+  quotedReplies: RepliesOptions.SUBSCRIBE_TO_MENTIONS,
   reactions: ReactionsOptions.SUBSCRIBE_TO_REACTIONS_ON_ALL_MESSAGES);
 
 // Load the updates in the NotificationPreferences instance.


### PR DESCRIPTION
## Description

Adds documentation for the new `quotedReplies` notification preference introduced in ENG-34512. This preference controls notifications for swipe-to-reply (quoted) messages, separate from the existing `replies` preference which handles threaded (parentId) replies.

## Related Issue(s)

- Linear: [ENG-35766](https://linear.app/cometchat/issue/ENG-35766/document-quotedreplies-notification-preference)
- Backend PR: https://github.com/cometchat-team/cometchat-notifications-core/pull/216
- Dashboard PR: https://github.com/cometchat-team/customer-dashboard/pull/2433

## Type of Change

- [ ] Documentation correction/update
- [x] New documentation
- [x] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

### Changes in `notifications/preferences.mdx`
- Added "New quoted replies" row to Group preferences dashboard table
- Added "New quoted replies" row to One-on-one preferences dashboard table
- Added `getQuotedRepliesPreference()` / `setQuotedRepliesPreference()` to all SDK code snippets (JS, Android, iOS, Flutter) for both group and one-on-one fetch/update

### Changes in `chat-apis.json` (OpenAPI spec)
- Added `quotedRepliesSetting` and `quotedRepliesOverride` to group and oneOnOne settings schemas
- Added `groupQuotedReplies` and `oneOnOneQuotedReplies` to preferences update schema
- Added `QUOTED_REPLIES_PREFERENCE` to notification logs reason enum
- Updated all example response objects with the new fields

### Default behavior
"Notify for all replies" — no behavior change for existing users until they configure this preference.