### PR TITLE
Add view slot examples, images, and CSS architecture to v7 docs

### DIFF
--- a/ui-kit/react/components/ai-assistant-chat.mdx
+++ b/ui-kit/react/components/ai-assistant-chat.mdx
@@ -288,7 +288,149 @@ Use view props to replace sections of the default UI while keeping the component
 | `headerTrailingView` | `ReactNode` | Header trailing section |
 | `headerAuxiliaryButtonView` | `ReactNode` | Header auxiliary buttons (New Chat + History) |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the AI assistant chat */}
+#### emptyChatImageView
+
+<Frame>
+  <img src="/images/react-uikit_ai-assistant-chat-empty_chat_image_view.png" />
+</Frame>
+
+```tsx
+import { useState, useEffect } from "react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatAIAssistantChat } from "@cometchat/chat-uikit-react";
+
+function AIAssistantCustomImage() {
+  const [agent, setAgent] = useState<CometChat.User>();
+
+  useEffect(() => {
+    CometChat.getUser("assistant_uid").then((u) => setAgent(u));
+  }, []);
+
+  if (!agent) return null;
+
+  return (
+    <CometChatAIAssistantChat
+      user={agent}
+      emptyChatImageView={<img src={"ICON_URL"} height={60} width={60} alt="" />}
+    />
+  );
+}
+```
+
+#### emptyChatGreetingView
+
+<Frame>
+  <img src="/images/react-uikit_ai-assistant-chat-empty_chat_greeeting_view.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { useState, useEffect } from "react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatAIAssistantChat } from "@cometchat/chat-uikit-react";
+
+function AIAssistantCustomGreeting() {
+  const [agent, setAgent] = useState<CometChat.User>();
+
+  useEffect(() => {
+    CometChat.getUser("assistant_uid").then((u) => setAgent(u));
+  }, []);
+
+  if (!agent) return null;
+
+  return (
+    <CometChatAIAssistantChat
+      user={agent}
+      emptyChatGreetingView={
+        <div className="cometchat-ai-assistant-chat__empty-chat-greeting">
+          <span className="plan-name">Free Plan</span> .
+          <span className="upgrade-button">Upgrade</span>
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-ai-assistant-chat__empty-chat-greeting {
+  display: flex;
+  padding: 8px 20px;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  border-radius: 6px;
+  border: 1px solid #e8e8e8;
+  background: #f5f5f5;
+  width: fit-content;
+  align-self: center;
+}
+
+.cometchat-ai-assistant-chat__empty-chat-greeting .upgrade-button {
+  color: #6852d6;
+}
+```
+</Tab>
+</Tabs>
+
+#### emptyChatIntroMessageView
+
+<Frame>
+  <img src="/images/react-uikit_ai-assistant-chat-empty_chat_intro_message_view.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { useState, useEffect } from "react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatAIAssistantChat } from "@cometchat/chat-uikit-react";
+
+function AIAssistantCustomIntro() {
+  const [agent, setAgent] = useState<CometChat.User>();
+
+  useEffect(() => {
+    CometChat.getUser("assistant_uid").then((u) => setAgent(u));
+  }, []);
+
+  if (!agent) return null;
+
+  return (
+    <CometChatAIAssistantChat
+      user={agent}
+      emptyChatIntroMessageView={
+        <div className="cometchat-ai-assistant-chat__empty-chat-intro">
+          Hey, nice to see you What's new?
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-ai-assistant-chat__empty-chat-intro {
+  display: flex;
+  padding: 12px;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  border-radius: 12px;
+  background: #f9f8fd;
+  width: 172px;
+  color: #141414;
+  text-align: center;
+  font-size: 16px;
+  font-weight: 400;
+  line-height: 140%;
+  margin: 10px 0;
+}
+```
+</Tab>
+</Tabs>
 
 ### CSS Styling
 

--- a/ui-kit/react/components/call-logs.mdx
+++ b/ui-kit/react/components/call-logs.mdx
@@ -241,8 +241,6 @@ Use view props to replace sections of the default UI while keeping the component
 | `emptyView` | `ReactNode` | Empty state |
 | `errorView` | `ReactNode` | Error state |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the call log item */}
-
 ### CSS Styling
 
 Override design tokens on the component selector:

--- a/ui-kit/react/components/conversations.mdx
+++ b/ui-kit/react/components/conversations.mdx
@@ -77,8 +77,7 @@ description: "Scrollable list of recent one-on-one and group conversations for t
       "searchView": "ReactNode",
       "loadingView": "ReactNode",
       "emptyView": "ReactNode",
-      "errorView": "ReactNode",
-      "options": "(conversation: CometChat.Conversation) => CometChatConversationOption[]"
+      "errorView": "ReactNode"
     }
   },
   "events": [
@@ -134,7 +133,7 @@ description: "Scrollable list of recent one-on-one and group conversations for t
 
 `CometChatConversations` is a sidebar list component. It renders recent conversations for the logged-in user and emits the selected `CometChat.Conversation` via `onItemClick`. Wire it to `CometChatMessageHeader`, `CometChatMessageList`, and `CometChatMessageComposer` to build a standard two-panel chat layout.
 
-{/* TODO:IMAGE - CometChatConversations component showing a list of conversations with avatars, names, last messages, timestamps, and unread badges */}
+<Frame><img src="/images/two_panel_layout_without_tabs_react_v7.png" /></Frame>
 
 <Info>
 **Live Preview** — interact with the default conversations list.
@@ -155,7 +154,6 @@ The component handles:
 - Paginated fetching with infinite scroll
 - Real-time updates (new messages, typing indicators, presence changes)
 - Search filtering
-- Swipe/hover options (delete conversation)
 - Selection mode (single/multiple)
 
 ---
@@ -371,7 +369,447 @@ Use view props to replace sections of the default UI while keeping the component
 | `emptyView` | `ReactNode` | Empty state |
 | `errorView` | `ReactNode` | Error state |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the conversation item */}
+#### itemView
+
+Replace the entire list item row.
+
+Default:
+
+<Frame>
+  <img src="/images/264a5cc0-list_item_view_default_web_screens-981f3ae54a9cef1c1f774bbda2f05a81.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/288ed9bb-list_item_view_custom_web_screens-84bd7def72c71696e4ecb34d0ace5341.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import {
+  CometChatConversations,
+  CometChatAvatar,
+  CometChatDate,
+} from "@cometchat/chat-uikit-react";
+
+function CustomItemViewConversations() {
+  const getItemView = (conversation: CometChat.Conversation) => {
+    const title = conversation.getConversationWith().getName();
+    const timestamp = conversation?.getLastMessage()?.getSentAt();
+
+    return (
+      <div className="conversations__custom-item">
+        <CometChatAvatar.Root name={title}>
+          <CometChatAvatar.Image />
+          <CometChatAvatar.Initials />
+        </CometChatAvatar.Root>
+        <span className="conversations__custom-item-title">{title}</span>
+        {timestamp ? (
+          <CometChatDate.Root timestamp={timestamp}>
+            <CometChatDate.Text />
+          </CometChatDate.Root>
+        ) : null}
+      </div>
+    );
+  };
+
+  return <CometChatConversations itemView={getItemView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.conversations__custom-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  width: 100%;
+}
+
+.conversations__custom-item-title {
+  flex: 1;
+  font: 500 16px/19.2px Roboto;
+  color: #141414;
+}
+
+.cometchat-conversations .cometchat-avatar {
+  border-radius: 8px;
+  width: 32px;
+  height: 32px;
+}
+```
+</Tab>
+</Tabs>
+
+#### leadingView
+
+Replace the avatar / left section. Typing-aware avatar example.
+
+<Frame>
+  <img src="/images/5f55a4a0-conversations_leadingview-3b297f3151794854485fc087d0c0aeec.png" />
+</Frame>
+
+```tsx
+import { useEffect, useRef, useState } from "react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import {
+  CometChatConversations,
+  CometChatAvatar,
+  useLoggedInUser,
+} from "@cometchat/chat-uikit-react";
+
+function TypingAwareConversations() {
+  const [isTyping, setIsTyping] = useState(false);
+  const typingObjRef = useRef<CometChat.TypingIndicator | null>(null);
+  const loggedInUser = useLoggedInUser();
+
+  useEffect(() => {
+    const listenerId = "typing_demo_" + Date.now();
+    CometChat.addMessageListener(
+      listenerId,
+      new CometChat.MessageListener({
+        onTypingStarted: (typingIndicator: CometChat.TypingIndicator) => {
+          typingObjRef.current = typingIndicator;
+          setIsTyping(true);
+        },
+        onTypingEnded: (typingIndicator: CometChat.TypingIndicator) => {
+          if (
+            typingObjRef.current &&
+            typingObjRef.current.getSender().getUid() ===
+              typingIndicator.getSender().getUid()
+          ) {
+            typingObjRef.current = null;
+            setIsTyping(false);
+          }
+        },
+      })
+    );
+    return () => {
+      CometChat.removeMessageListener(listenerId);
+    };
+  }, []);
+
+  const getLeadingView = (conversation: CometChat.Conversation) => {
+    const entity = conversation.getConversationWith();
+    const isUser = entity instanceof CometChat.User;
+    const isGroup = entity instanceof CometChat.Group;
+
+    const isMyTyping = isUser
+      ? (entity as CometChat.User).getUid() ===
+          typingObjRef.current?.getSender().getUid() &&
+        loggedInUser?.getUid() === typingObjRef.current?.getReceiverId()
+      : isGroup &&
+        (entity as CometChat.Group).getGuid() ===
+          typingObjRef.current?.getReceiverId();
+
+    const avatar = isUser
+      ? (entity as CometChat.User).getAvatar()
+      : (entity as CometChat.Group).getIcon();
+
+    return (
+      <div className="conversations__leading-view">
+        <CometChatAvatar.Root
+          image={isTyping && isMyTyping ? undefined : avatar}
+          name={isTyping && isMyTyping ? undefined : entity.getName()}
+        >
+          <CometChatAvatar.Image />
+          <CometChatAvatar.Initials />
+        </CometChatAvatar.Root>
+      </div>
+    );
+  };
+
+  return <CometChatConversations leadingView={getLeadingView} />;
+}
+```
+
+#### titleView
+
+Replace the name / title text. Inline user status example.
+
+<Frame>
+  <img src="/images/015d947c-conversations_titleview-b5822bb42232ef47727b553cbf1facd8.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatConversations } from "@cometchat/chat-uikit-react";
+
+function StatusTitleConversations() {
+  const getTitleView = (conversation: CometChat.Conversation) => {
+    const user =
+      conversation.getConversationType() === "user"
+        ? (conversation.getConversationWith() as CometChat.User)
+        : undefined;
+
+    return (
+      <div className="conversations__title-view">
+        <span className="conversations__title-view-name">
+          {user
+            ? conversation.getConversationWith().getName() + " · "
+            : conversation.getConversationWith().getName()}
+        </span>
+        {user && (
+          <span className="conversations__title-view-status">
+            {user.getStatusMessage()}
+          </span>
+        )}
+      </div>
+    );
+  };
+
+  return <CometChatConversations titleView={getTitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-conversations .conversations__title-view {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+}
+
+.conversations__title-view-name {
+  color: #141414;
+  font: 500 16px/19.2px Roboto;
+}
+
+.conversations__title-view-status {
+  color: #6852d6;
+  font: 400 16px/19.2px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### subtitleView
+
+Replace the last message preview text.
+
+Default:
+
+<Frame>
+  <img src="/images/68f87420-subtitle_View_default_web_screens-981f3ae54a9cef1c1f774bbda2f05a81.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/a5a0ef3f-subtitle_View_custom_web_screens-cc38fdf73a8f272804d2c3b73e898ce5.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatConversations } from "@cometchat/chat-uikit-react";
+
+function formatTimestamp(timestamp: number): string {
+  return new Date(timestamp * 1000).toLocaleString();
+}
+
+function SubtitleConversations() {
+  const getSubtitleView = (conversation: CometChat.Conversation) => {
+    if (conversation.getConversationType() === "user") {
+      return (
+        <span className='custom-conversation-subtitle'>
+          Last active:{" "}
+          {new Date(
+            (conversation.getConversationWith() as CometChat.User).getLastActiveAt() * 1000
+          ).toLocaleString()}
+        </span>
+      );
+    }
+    return (
+      <span className='custom-conversation-subtitle'>
+        Created:{" "}
+        {new Date(
+          (conversation.getConversationWith() as CometChat.Group).getCreatedAt() * 1000
+        ).toLocaleString()}
+      </span>
+    );
+  };
+
+  return <CometChatConversations subtitleView={getSubtitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.custom-conversation-subtitle {
+  overflow: hidden;
+  color: grey;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: var(--cometchat-font-body-regular);
+}
+```
+</Tab>
+</Tabs>
+
+#### trailingView
+
+Replace the timestamp / badge / right section. Relative time badge example.
+
+<Frame>
+  <img src="/images/13a712d0-conversations_trailingview-3aecd22196f2ccfb66af2b9a00d2c93f.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatConversations } from "@cometchat/chat-uikit-react";
+
+function RelativeTimeConversations() {
+  const getTrailingView = (conv: CometChat.Conversation) => {
+    if (!conv.getLastMessage()) return <></>;
+
+    const timestamp = conv.getLastMessage()?.getSentAt() * 1000;
+    const now = Date.now();
+    const diffInMinutes = Math.floor((now - timestamp) / (1000 * 60));
+    const diffInHours = Math.floor((now - timestamp) / (1000 * 60 * 60));
+
+    let className = "conversations__trailing-view-min";
+    let topLabel = `${diffInMinutes}`;
+    let bottomLabel = diffInMinutes === 1 ? "Min ago" : "Mins ago";
+
+    if (diffInHours >= 1 && diffInHours <= 10) {
+      className = "conversations__trailing-view-hour";
+      topLabel = `${diffInHours}`;
+      bottomLabel = diffInHours === 1 ? "Hour ago" : "Hours ago";
+    } else if (diffInHours > 10) {
+      className = "conversations__trailing-view-date";
+      const time = new Date(timestamp);
+      topLabel = time.toLocaleDateString("en-US", { day: "numeric" });
+      bottomLabel = time.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+    }
+
+    return (
+      <div className={`conversations__trailing-view ${className}`}>
+        <span className="conversations__trailing-view-time">{topLabel}</span>
+        <span className="conversations__trailing-view-status">{bottomLabel}</span>
+      </div>
+    );
+  };
+
+  return <CometChatConversations trailingView={getTrailingView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.conversations__trailing-view {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 55px;
+  height: 40px;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.conversations__trailing-view-min { background-color: #e0d4f7; }
+.conversations__trailing-view-hour { background-color: #fff3cd; }
+.conversations__trailing-view-date { background-color: #f8d7da; }
+
+.conversations__trailing-view-time {
+  font: 600 18px Roboto;
+  color: #4a3f99;
+  margin-bottom: 4px;
+}
+
+.conversations__trailing-view-status {
+  font: 600 8px Roboto;
+  color: #6a5b99;
+}
+
+.cometchat-conversations .cometchat-list-item__trailing-view {
+  height: 50px;
+}
+```
+</Tab>
+</Tabs>
+
+#### headerView
+
+Replace the entire header bar.
+
+<Frame>
+  <img src="/images/c8e9953f-conversations_headerview-334738e0afe495ef89165ee0cea86b5c.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import {
+  CometChatButton,
+  CometChatConversations,
+  useLocale,
+} from "@cometchat/chat-uikit-react";
+
+function CustomHeaderConversations() {
+  const { getLocalizedString } = useLocale();
+
+  return (
+    <CometChatConversations
+      headerView={
+        <div className="conversations__header">
+          <div className="conversations__header__title">
+            {getLocalizedString("chats")}
+          </div>
+          <CometChatButton.Root onClick={() => { /* handle click */ }}>
+            <CometChatButton.Icon />
+          </CometChatButton.Root>
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.conversations__header {
+  display: flex;
+  width: 100%;
+  padding: 8px 16px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: 10px;
+  border: 1px solid #e8e8e8;
+  background: #edeafa;
+}
+
+.conversations__header__title {
+  overflow: hidden;
+  color: #141414;
+  text-overflow: ellipsis;
+  font: 700 24px Roboto;
+}
+
+.conversations__header .cometchat-button .cometchat-button__icon {
+  background: #141414;
+}
+
+.conversations__header .cometchat-button {
+  width: 24px;
+  border: none;
+  background: transparent;
+  border-radius: 0;
+}
+```
+</Tab>
+</Tabs>
 
 ### Compound Composition
 
@@ -589,36 +1027,6 @@ Custom sound URL to play when new messages arrive (replaces the built-in sound).
 
 ---
 
-### options
-
-Function that returns context menu options for each conversation item (shown on hover/swipe).
-
-| | |
-| --- | --- |
-| Type | `(conversation: CometChat.Conversation) => CometChatConversationOption[]` |
-| Default | Default options (delete) |
-
-```tsx
-<CometChatConversations
-  options={(conversation) => [
-    {
-      id: "pin",
-      title: "Pin",
-      iconURL: pinIcon,
-      onClick: (conv) => pinConversation(conv),
-    },
-    {
-      id: "mute",
-      title: "Mute",
-      iconURL: muteIcon,
-      onClick: (conv) => muteConversation(conv),
-    },
-  ]}
-/>
-```
-
----
-
 ### onItemClick
 
 Callback when a conversation item is clicked.
@@ -674,24 +1082,89 @@ Callback when the search bar is clicked. When provided, the search input becomes
 
 ---
 
-## CSS Selectors
+## CSS Architecture
+
+The component uses CSS custom properties (design tokens) that are bundled with `@cometchat/chat-uikit-react`. The cascade:
+
+1. Global tokens (e.g., `--cometchat-primary-color`, `--cometchat-background-color-01`) are set on the `.cometchat` root wrapper.
+2. Component CSS (`.cometchat-conversations`) consumes these tokens via `var()` with fallback values.
+3. Overrides target `.cometchat-conversations` descendant selectors in a global stylesheet.
+
+To scope overrides to a single instance when multiple `CometChatConversations` exist on the same page, wrap the component in a container and scope selectors:
+
+```css
+.sidebar-left .cometchat-conversations .cometchat-badge {
+  background: #e5484d;
+}
+```
+
+Overrides survive component updates because the component never sets inline styles on these elements — all styling flows through CSS classes and custom properties.
+
+### Key Selectors
 
 | Target | Selector |
 | --- | --- |
-| Root container | `.cometchat-conversations` |
-| Header | `.cometchat-conversations__header` |
-| Search bar | `.cometchat-conversations__search-bar` |
-| List container | `.cometchat-conversations__list` |
-| Conversation item | `.cometchat-conversations__item` |
-| Active item | `.cometchat-conversations__item--active` |
-| Item avatar | `.cometchat-conversations__item-avatar` |
-| Item title | `.cometchat-conversations__item-title` |
-| Item subtitle | `.cometchat-conversations__item-subtitle` |
-| Item trailing | `.cometchat-conversations__item-trailing` |
-| Unread badge | `.cometchat-conversations__item-unread-count` |
-| Empty state | `.cometchat-conversations__empty-state` |
-| Error state | `.cometchat-conversations__error-state` |
-| Loading state | `.cometchat-conversations__loading-state` |
+| Root | `.cometchat-conversations` |
+| Header title | `.cometchat-conversations .cometchat-list__header-title` |
+| List item | `.cometchat-conversations .cometchat-list-item` |
+| Body title | `.cometchat-conversations .cometchat-list-item__body-title` |
+| Avatar | `.cometchat-conversations .cometchat-avatar` |
+| Avatar text | `.cometchat-conversations .cometchat-avatar__text` |
+| Unread badge | `.cometchat-conversations .cometchat-badge` |
+| Subtitle text | `.cometchat-conversations .cometchat-conversations__subtitle-text` |
+| Status indicator | `.cometchat-conversations .cometchat-status-indicator` |
+| Read receipts | `.cometchat-conversations .cometchat-receipts-read` |
+| Active item | `.cometchat-conversations__list-item-active .cometchat-list-item` |
+| Typing indicator | `.cometchat-conversations__subtitle-typing` |
+| Trailing view | `.cometchat-conversations__trailing-view` |
+
+### Example: Brand-themed conversations
+
+<Frame>
+  <img src="/images/46655ced-style_custom_web_screens-967e2c7c42b5c97c59c10a9212aef0c4.png" />
+</Frame>
+
+```css
+.cometchat-conversations .cometchat-conversations__item-title,
+.cometchat-conversations .cometchat-conversations__header-title,
+.cometchat-conversations .cometchat-avatar__text,
+.cometchat-conversations .cometchat-conversations__item-unread-badge,
+.cometchat-conversations .cometchat-conversations__item-subtitle-text {
+  font-family: "SF Pro";
+}
+
+.cometchat-conversations .cometchat-conversations__header {
+  background: #fef8f8;
+  border-bottom: 2px solid #f4b6b8;
+}
+
+.cometchat-conversations .cometchat-avatar {
+  background: #FAAA75;
+}
+
+.cometchat-conversations .cometchat-status-indicator {
+  min-width: 10px;
+  height: 10px;
+}
+
+.cometchat-conversations .cometchat-conversations__item-unread-badge {
+  background: #F76809;
+}
+
+.cometchat-conversations .cometchat-conversations__item-receipt--read {
+  background: #FAAA75;
+}
+```
+
+### Customization Matrix
+
+| What to change | Where | Property/API | Example |
+| --- | --- | --- | --- |
+| Override behavior on user interaction | Component props | `on<Event>` callbacks | `onItemClick={(c) => setActive(c)}` |
+| Filter which conversations appear | Component props | `conversationsRequestBuilder` | `conversationsRequestBuilder={new CometChat.ConversationsRequestBuilder().setLimit(10)}` |
+| Toggle visibility of UI elements | Component props | `hide<Feature>` boolean props | `hideReceipts={true}` |
+| Replace a section of the list item | Component props | `<slot>View` render props | `itemView={(conversation) => <div>...</div>}` |
+| Change colors, fonts, spacing | Global CSS | Target `.cometchat-conversations` class | `.cometchat-conversations .cometchat-badge { background: #e5484d; }` |
 
 ---
 

--- a/ui-kit/react/components/group-members.mdx
+++ b/ui-kit/react/components/group-members.mdx
@@ -326,7 +326,310 @@ Use view props to replace sections of the default UI while keeping the component
 | `emptyView` | `ReactNode` | Empty state |
 | `errorView` | `ReactNode` | Error state |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the group member item */}
+#### itemView
+
+Replace the entire list item row.
+
+Default:
+
+<Frame>
+  <img src="/images/a4ba8be1-group_members_listitemview_default_web_screens-5b8840bd6f3ce2799707ce7ea2951e89.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/e0d9b4dc-group_members_listitemview_custom_web_screens-c804cdfd10e7e040c95f65ecfa045421.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import {
+  CometChatAvatar,
+  CometChatGroupMembers,
+} from "@cometchat/chat-uikit-react";
+
+function CustomItemViewMembers({ group }: { group: CometChat.Group }) {
+  const getItemView = (member: CometChat.GroupMember) => {
+    const scope = member.getScope();
+    return (
+      <div className="group-member-list-item">
+        <div className="group-member-list-item__avatar">
+          <CometChatAvatar.Root image={member.getAvatar()} name={member.getName()}>
+            <CometChatAvatar.Image />
+            <CometChatAvatar.Initials />
+          </CometChatAvatar.Root>
+        </div>
+        <div className="group-member-list-item__content">
+          <div className="group-member-list-item__content-name">{member.getName()}</div>
+          <div className={`group-member-list-item__content-tag group-member-list-item__content-tag-${scope}`}>
+            {scope}
+          </div>
+        </div>
+      </div>
+    );
+  };
+
+  return <CometChatGroupMembers group={group} itemView={getItemView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.group-member-list-item {
+  display: flex;
+  min-width: 240px;
+  padding: 8px 16px;
+  align-items: center;
+  gap: 12px;
+  background: #fff;
+}
+
+.group-member-list-item__content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+}
+
+.cometchat-avatar, .cometchat-avatar__image {
+  border-radius: 10px;
+}
+
+.group-member-list-item__content-name {
+  overflow: hidden;
+  color: #141414;
+  text-overflow: ellipsis;
+  font: 500 16px Roboto;
+}
+
+.group-member-list-item__content-tag {
+  display: flex;
+  padding: 4px 12px;
+  border-radius: 1000px;
+  background: #edeafa;
+  color: #6852d6;
+  font: 400 12px Roboto;
+}
+
+.group-member-list-item__content-tag-owner {
+  background: #6852d6;
+  color: #fff;
+}
+
+.group-member-list-item__content-tag-admin {
+  border: 1px solid #6852d6;
+}
+
+.group-member-list-item__content-tag-participant {
+  display: none;
+}
+```
+</Tab>
+</Tabs>
+
+#### subtitleView
+
+Replace the subtitle text. Joined date example.
+
+Default:
+
+<Frame>
+  <img src="/images/61f20b67-group_members_subtitleview_default_web_screens-9f5cd5b191f8d3dfdec49a6cd0997c55.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/923f8e60-group_members_subtitleview_custom_web_screens-805d87b822b312ce9afd8aaee10ae20d.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatGroupMembers } from "@cometchat/chat-uikit-react";
+
+function SubtitleMembers({ group }: { group: CometChat.Group }) {
+  const getSubtitleView = (member: CometChat.GroupMember) => {
+    const date = new Date(member.getJoinedAt() * 1000).toLocaleDateString();
+    return <div className="group-member-subtitle">Joined: {date}</div>;
+  };
+
+  return <CometChatGroupMembers group={group} subtitleView={getSubtitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.group-member-subtitle {
+  overflow: hidden;
+  color: #727272;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: 400 14px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### trailingView
+
+Replace the right section. Scope tag example.
+
+Default:
+
+<Frame>
+  <img src="/images/77b0d08c-group_members_tailview_default_web_screens-9f5cd5b191f8d3dfdec49a6cd0997c55.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/1c4e58ee-group_members_tailview_custom_web_screens-055d509a3005e4999becda952d9001e3.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatGroupMembers } from "@cometchat/chat-uikit-react";
+
+function TrailingViewMembers({ group }: { group: CometChat.Group }) {
+  const getTrailingView = (member: CometChat.GroupMember) => {
+    return (
+      <div className="group-member-scope-tag">
+        {member.getScope()}
+      </div>
+    );
+  };
+
+  return <CometChatGroupMembers group={group} trailingView={getTrailingView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.group-member-scope-tag {
+  display: flex;
+  padding: 4px 12px;
+  border-radius: 1000px;
+  background: #edeafa;
+  color: #6852d6;
+  font: 400 12px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### headerView
+
+Replace the entire header bar.
+
+<Frame>
+  <img src="/images/b33f809d-group_member_headerview-234678815906bbb7e26ae2bddb71f972.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import {
+  CometChatGroupMembers,
+  CometChatButton,
+  useLocale,
+} from "@cometchat/chat-uikit-react";
+
+function CustomHeaderMembers({ group }: { group: CometChat.Group }) {
+  const { getLocalizedString } = useLocale();
+
+  return (
+    <CometChatGroupMembers
+      group={group}
+      headerView={
+        <div className="group-members__header">
+          <div className="group-members__header__title">
+            {getLocalizedString("group_members")}
+          </div>
+          <CometChatButton.Root onClick={() => { /* handle click */ }}>
+            <CometChatButton.Icon />
+          </CometChatButton.Root>
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.group-members__header {
+  display: flex;
+  width: 100%;
+  padding: 8px 16px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-radius: 10px;
+  border: 1px solid #e8e8e8;
+  background: #edeafa;
+}
+
+.group-members__header__title {
+  overflow: hidden;
+  color: #141414;
+  text-overflow: ellipsis;
+  font: 700 24px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### options
+
+Replace the context menu / hover actions on each member item.
+
+<Frame>
+  <img src="/images/7ce43a63-group_members_options_web_screens-c7a97fe4857af207bf473eb087d15f65.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import {
+  CometChatGroupMembers,
+  type CometChatGroupMemberOption,
+} from "@cometchat/chat-uikit-react";
+
+function CustomOptionsMembers({ group }: { group: CometChat.Group }) {
+  const getOptions = (member: CometChat.GroupMember): CometChatGroupMemberOption[] => [
+    {
+      id: "kick",
+      title: "Kick User",
+      onClick: (m) => { /* kick logic */ },
+    },
+  ];
+
+  return <CometChatGroupMembers group={group} options={getOptions} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-group-members .cometchat-menu-list__main-menu-item-icon {
+  background: #f44649;
+}
+
+.cometchat-group-members .cometchat-menu-list__menu {
+  background: transparent;
+  box-shadow: none;
+}
+```
+</Tab>
+</Tabs>
 
 ### Compound Composition
 

--- a/ui-kit/react/components/groups.mdx
+++ b/ui-kit/react/components/groups.mdx
@@ -343,7 +343,214 @@ Use view props to replace sections of the default UI while keeping the component
 | `emptyView` | `ReactNode` | Empty state |
 | `errorView` | `ReactNode` | Error state |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the group item */}
+#### itemView
+
+Replace the entire list item row.
+
+Default:
+
+<Frame>
+  <img src="/images/d7c86ab4-groups_listItemView_default_web_screens-76f09cda3f72c774c46829a547f37f3d.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/2c6dea55-groups_listItemView_custom_web_screens-a982a860cd750f68bb9409701f0e2267.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatGroups } from "@cometchat/chat-uikit-react";
+
+function CustomItemViewGroups() {
+  const getItemView = (group: CometChat.Group) => {
+    return (
+      <div className="group-list-item">
+        <div className="group-list-item__title-wrapper">
+          <div className="group-list-item__title">{group.getName()}</div>
+          <div className="group-list-item__tail">JOIN</div>
+        </div>
+        <div className="group-list-item__subtitle">
+          {group.getMembersCount()} Members • {group.getDescription()}
+        </div>
+      </div>
+    );
+  };
+
+  return <CometChatGroups itemView={getItemView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.group-list-item {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+  min-width: 240px;
+  padding: 8px 16px;
+  gap: 4px;
+  flex: 1 0 0;
+  border-right: 1px solid #f5f5f5;
+  background: #fff;
+}
+
+.group-list-item:hover {
+  background-color: #f5f5f5;
+}
+
+.group-list-item__title-wrapper {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  align-self: stretch;
+}
+
+.group-list-item__title {
+  overflow: hidden;
+  color: #141414;
+  text-overflow: ellipsis;
+  font: 500 16px Roboto;
+}
+
+.group-list-item__tail {
+  display: flex;
+  padding: 4px 12px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 1000px;
+  background: #edeafa;
+  overflow: hidden;
+  color: #6852d6;
+  text-overflow: ellipsis;
+  font: 700 12px Roboto;
+}
+
+.group-list-item__subtitle {
+  overflow: hidden;
+  color: #727272;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: 400 14px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### titleView
+
+Replace the name / title text. Group type badge inline example.
+
+<Frame>
+  <img src="/images/1407ea86-groups_custom_titleview_web_screens-54ca7045e948a252b07729ffc10dbc15.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatGroups } from "@cometchat/chat-uikit-react";
+
+function GroupTypeTitleGroups() {
+  const getTitleView = (group: CometChat.Group) => {
+    return (
+      <div className={`groups__title-view groups__title-view-${group.getType()}`}>
+        <span className="groups__title-view-name">{group.getName()}</span>
+        <span className="groups__title-view-type">{group.getType()}</span>
+      </div>
+    );
+  };
+
+  return <CometChatGroups titleView={getTitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.groups__title-view {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  align-self: stretch;
+}
+
+.groups__title-view-name {
+  overflow: hidden;
+  color: #141414;
+  text-overflow: ellipsis;
+  font: 500 16px Roboto;
+}
+
+.groups__title-view-type {
+  color: #fff;
+  font: 600 8px Roboto;
+  display: flex;
+  height: 15px;
+  padding: 1px 3px;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  border-radius: 7px;
+  background: #09c26f;
+}
+
+.groups__title-view-public .groups__title-view-type {
+  background: #0b7bea;
+}
+```
+</Tab>
+</Tabs>
+
+#### subtitleView
+
+Replace the member count subtitle text.
+
+Default:
+
+<Frame>
+  <img src="/images/fc8a44f2-groups_subtitleView_default_web_screens-ce55d4824eab1d506f7ff5b8b2bd3f03.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/d7df2f29-groups_subtitleView_custom_web_screens-2031bc808b39482f08506ce198d5dd36.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatGroups } from "@cometchat/chat-uikit-react";
+
+function SubtitleGroups() {
+  const getSubtitleView = (group: CometChat.Group) => {
+    return (
+      <div className="group-subtitle">
+        {group.getMembersCount()} Members • {group.getDescription()}
+      </div>
+    );
+  };
+
+  return <CometChatGroups subtitleView={getSubtitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-groups .group-subtitle {
+  overflow: hidden;
+  color: #727272;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: 400 14px Roboto;
+}
+```
+</Tab>
+</Tabs>
 
 ### Compound Composition
 

--- a/ui-kit/react/components/incoming-call.mdx
+++ b/ui-kit/react/components/incoming-call.mdx
@@ -223,7 +223,83 @@ Use view props to replace sections of the default UI while keeping the component
 | `subtitleView` | `(call: CometChat.Call) => ReactNode` | Call type label |
 | `trailingView` | `(call: CometChat.Call) => ReactNode` | Trailing section |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the incoming call notification */}
+#### leadingView
+
+<Frame>
+  <img src="/images/c3e4060d-incoming_call_leading_view_custom_web_screens-75333fe402b7588c590288cd6f825a99.png" />
+</Frame>
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatAvatar, CometChatIncomingCall } from "@cometchat/chat-uikit-react";
+
+function CustomLeadingIncoming() {
+  return (
+    <CometChatIncomingCall
+      leadingView={(call: CometChat.Call) => (
+        <CometChatAvatar.Root
+          name={call.getCallInitiator()?.getName()}
+          image={call.getCallInitiator()?.getAvatar()}
+        >
+          <CometChatAvatar.Image />
+          <CometChatAvatar.Initials />
+        </CometChatAvatar.Root>
+      )}
+    />
+  );
+}
+```
+
+#### titleView
+
+<Frame>
+  <img src="/images/8d3bfa9b-incoming_call_title_view_custom_web_screens-67b55f5b6fc1ede3f9f55d840ebaa290.png" />
+</Frame>
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatIncomingCall } from "@cometchat/chat-uikit-react";
+
+function CustomTitleIncoming() {
+  return (
+    <CometChatIncomingCall
+      titleView={(call: CometChat.Call) => (
+        <div>{call.getCallInitiator()?.getName()}</div>
+      )}
+    />
+  );
+}
+```
+
+#### itemView
+
+<Frame>
+  <img src="/images/40f39b71-incoming_call_item_view_custom_web_screens-f8cd3984730f17f99313f1d988439d41.png" />
+</Frame>
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatAvatar, CometChatIncomingCall } from "@cometchat/chat-uikit-react";
+
+function CustomItemViewIncoming() {
+  return (
+    <CometChatIncomingCall
+      itemView={(call: CometChat.Call) => (
+        <div className="incoming-call__item">
+          <CometChatAvatar.Root
+            name={call.getCallInitiator()?.getName()}
+            image={call.getCallInitiator()?.getAvatar()}
+          >
+            <CometChatAvatar.Image />
+            <CometChatAvatar.Initials />
+          </CometChatAvatar.Root>
+          <div>{call.getCallInitiator()?.getName()}</div>
+        </div>
+      )}
+    />
+  );
+}
+```
 
 ### CSS Styling
 

--- a/ui-kit/react/components/message-composer.mdx
+++ b/ui-kit/react/components/message-composer.mdx
@@ -324,7 +324,79 @@ Use view props to replace sections of the default UI while keeping the component
 | `auxiliaryButtonView` | `ReactNode` | Additional buttons in the actions area |
 | `headerView` | `ReactNode` | Header area above the input |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the composer */}
+#### attachmentOptions
+
+Override the default attachment options.
+
+<Frame>
+  <img src="/images/abb9806d-message_composer_custom_attachment_options_web_screens-104035717491a170e498d72a5a5591a2.png" />
+</Frame>
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageComposer } from "@cometchat/chat-uikit-react";
+
+function ComposerCustomAttachments({ chatUser }: { chatUser: CometChat.User }) {
+  return (
+    <CometChatMessageComposer
+      user={chatUser}
+      hideAttachments={{ audio: true, video: true }}
+    />
+  );
+}
+```
+
+#### auxiliaryButtonView
+
+Replace the auxiliary button area.
+
+<Frame>
+  <img src="/images/b504b88f-AAAAAElFTkSuQmCC.png" />
+</Frame>
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageComposer, CometChatButton } from "@cometchat/chat-uikit-react";
+
+function ComposerCustomAuxiliary({ chatUser }: { chatUser: CometChat.User }) {
+  return (
+    <CometChatMessageComposer
+      user={chatUser}
+      auxiliaryButtonView={
+        <CometChatButton.Root onClick={() => {}}>
+          <CometChatButton.Icon />
+        </CometChatButton.Root>
+      }
+    />
+  );
+}
+```
+
+#### sendButtonView
+
+Replace the send button.
+
+<Frame>
+  <img src="/images/741cf254-B4D17HCxfO1pwAAAABJRU5ErkJggg.png" />
+</Frame>
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageComposer, CometChatButton } from "@cometchat/chat-uikit-react";
+
+function ComposerCustomSend({ chatUser }: { chatUser: CometChat.User }) {
+  return (
+    <CometChatMessageComposer
+      user={chatUser}
+      sendButtonView={
+        <CometChatButton.Root onClick={() => {}}>
+          <CometChatButton.Icon />
+        </CometChatButton.Root>
+      }
+    />
+  );
+}
+```
 
 ### Compound Composition
 

--- a/ui-kit/react/components/message-header.mdx
+++ b/ui-kit/react/components/message-header.mdx
@@ -362,7 +362,155 @@ Use view props to replace sections of the default UI while keeping the component
 | `trailingView` | `ReactNode` | Call buttons + overflow menu |
 | `auxiliaryButtonView` | `ReactNode` | Auxiliary button area |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the message header */}
+#### itemView
+
+<Frame>
+  <img src="/images/0a3d38de-messages_header_list_item_view_web_screens-024979a70f09486b76e913633bfc9e81.png" />
+</Frame>
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageHeader, CometChatAvatar } from "@cometchat/chat-uikit-react";
+
+function CustomItemViewHeader({ user }: { user: CometChat.User }) {
+  return (
+    <CometChatMessageHeader
+      user={user}
+      leadingView={
+        <CometChatAvatar.Root name={user.getName()} image={user.getAvatar()}>
+          <CometChatAvatar.Image />
+          <CometChatAvatar.Initials />
+        </CometChatAvatar.Root>
+      }
+      titleView={<span>{user.getName()}</span>}
+      subtitleView={<span>{user.getStatus()}</span>}
+    />
+  );
+}
+```
+
+#### titleView
+
+<Frame>
+  <img src="/images/1ee88b50-message_header_custom_title_web_screens-d8b5c4b4ef21f6ea1e5e87c536ddfbd6.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageHeader } from "@cometchat/chat-uikit-react";
+
+function CustomTitleHeader({ user }: { user: CometChat.User }) {
+  return (
+    <CometChatMessageHeader
+      user={user}
+      titleView={
+        <div className="message-header__title-view">
+          <span className="message-header__title-view-name">
+            {user.getName() + " • "}
+          </span>
+          <span className="message-header__title-view-status">
+            {user.getStatusMessage()}
+          </span>
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-message-header .message-header__title-view {
+  display: flex;
+  gap: 4px;
+  width: 100%;
+}
+
+.message-header__title-view-name {
+  color: #141414;
+  font: 500 16px/19.2px Roboto;
+}
+
+.message-header__title-view-status {
+  color: #6852d6;
+  font: 400 16px/19.2px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### subtitleView
+
+<Frame>
+  <img src="/images/7f5924bc-messages_header_subtitle_view_web_screens-2b9e776b10d555785c6cdcc224433167.png" />
+</Frame>
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageHeader } from "@cometchat/chat-uikit-react";
+
+function CustomSubtitleHeader({ group }: { group: CometChat.Group }) {
+  return (
+    <CometChatMessageHeader
+      group={group}
+      subtitleView={
+        <>{group.getMembersCount() + " • " + group.getDescription()}</>
+      }
+    />
+  );
+}
+```
+
+#### leadingView
+
+<Frame>
+  <img src="/images/e084dde6-message_header_custom_leading_web_screens-fd38a005ae8bfcce9e2310031b1a90e5.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageHeader, CometChatAvatar } from "@cometchat/chat-uikit-react";
+
+function CustomLeadingHeader({ user }: { user: CometChat.User }) {
+  return (
+    <CometChatMessageHeader
+      user={user}
+      leadingView={
+        <div className="message-header__leading-view">
+          <CometChatAvatar.Root image={user.getAvatar()} name={user.getName()}>
+            <CometChatAvatar.Image />
+            <CometChatAvatar.Initials />
+          </CometChatAvatar.Root>
+          <span className="message-header__leading-view-role">
+            {user.getRole()}
+          </span>
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.message-header__leading-view {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+}
+
+.message-header__leading-view-role {
+  color: #6852d6;
+  font: 600 8px Roboto;
+}
+```
+</Tab>
+</Tabs>
 
 ### Compound Composition
 

--- a/ui-kit/react/components/message-list.mdx
+++ b/ui-kit/react/components/message-list.mdx
@@ -469,7 +469,122 @@ Use view props to replace sections of the default UI while keeping the component
 | `emptyView` | `ReactNode` | Empty state |
 | `errorView` | `ReactNode` | Error state |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the message list */}
+#### headerView
+
+Custom view above the message list.
+
+<Frame>
+  <img src="/images/3096c772-message_list_headerview_web_screens-c088625ffa7a992eeac85df186c320ec.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { useState, useEffect } from "react";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageList, CometChatButton } from "@cometchat/chat-uikit-react";
+
+function MessageListWithHeader() {
+  const [chatUser, setChatUser] = useState<CometChat.User>();
+
+  useEffect(() => {
+    CometChat.getUser("uid").then((user) => setChatUser(user));
+  }, []);
+
+  return chatUser ? (
+    <CometChatMessageList
+      user={chatUser}
+      headerView={
+        <div className="header-view">
+          <CometChatButton.Root>
+            <CometChatButton.Text>Notes</CometChatButton.Text>
+          </CometChatButton.Root>
+          <CometChatButton.Root>
+            <CometChatButton.Text>Pinned Message</CometChatButton.Text>
+          </CometChatButton.Root>
+          <CometChatButton.Root>
+            <CometChatButton.Text>Saved Links</CometChatButton.Text>
+          </CometChatButton.Root>
+        </div>
+      }
+    />
+  ) : null;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.header-view {
+  display: flex;
+  width: 100%;
+  padding: 3px 16px;
+  align-items: flex-start;
+  gap: 5px;
+  background: #edeafa;
+}
+
+.header-view .cometchat-button {
+  width: auto;
+  height: 32px;
+  border-radius: 1000px;
+  border: 1px solid #e8e8e8;
+  background: #fafafa;
+}
+
+.header-view .cometchat-button__text {
+  color: #6852d6;
+  font: 400 12px/14.4px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### footerView
+
+Custom view below the message list.
+
+<Frame>
+  <img src="/images/82f25a7d-message_list_footerview_web_screens-c277b86d74f0cdeb81c6ce7a7251383a.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatMessageList, CometChatButton } from "@cometchat/chat-uikit-react";
+
+function MessageListWithFooter({ chatUser }: { chatUser: CometChat.User }) {
+  return (
+    <CometChatMessageList
+      user={chatUser}
+      footerView={
+        <div className="footer-view">
+          <CometChatButton.Root>
+            <CometChatButton.Text>Ice Breakers</CometChatButton.Text>
+          </CometChatButton.Root>
+          <CometChatButton.Root>
+            <CometChatButton.Text>+1-212-456-7890</CometChatButton.Text>
+          </CometChatButton.Root>
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.footer-view {
+  display: flex;
+  width: 100%;
+  padding: 3px 16px;
+  align-items: flex-start;
+  gap: 5px;
+  background: #edeafa;
+}
+```
+</Tab>
+</Tabs>
 
 ### Compound Composition
 

--- a/ui-kit/react/components/outgoing-call.mdx
+++ b/ui-kit/react/components/outgoing-call.mdx
@@ -192,7 +192,133 @@ Use view props to replace sections of the default UI while keeping the component
 | `avatarView` | `ReactNode` | Receiver avatar |
 | `cancelButtonView` | `ReactNode` | End-call button |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the outgoing call screen */}
+#### titleView
+
+<Frame>
+  <img src="/images/294edd18-outgoing_calls_title_view_web_screens-bc3f5853236e03acb85aa532fd69706b.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatOutgoingCall } from "@cometchat/chat-uikit-react";
+
+function OutgoingCallCustomTitle({ call }: { call: CometChat.Call }) {
+  return (
+    <CometChatOutgoingCall
+      call={call}
+      titleView={
+        <div className="outgoing-call__title">
+          {call.getCallInitiator().getName()} {" <> "} {call.getCallReceiver().getName()}
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.outgoing-call__title {
+  color: #141414;
+  text-align: center;
+  font: 500 24px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### subtitleView
+
+<Frame>
+  <img src="/images/904cc985-outgoing_calls_subtitle_view_web_screens-ca75b11cc49d9955e040c37f05853a34.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatOutgoingCall } from "@cometchat/chat-uikit-react";
+
+function OutgoingCallCustomSubtitle({ call }: { call: CometChat.Call }) {
+  return (
+    <CometChatOutgoingCall
+      call={call}
+      subtitleView={
+        <div className="outgoing-call__subtitle">
+          <div className="outgoing-call__subtitle-icon" />
+          {"Calling..."}
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.outgoing-call__subtitle {
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 8px;
+  color: #727272;
+  text-align: center;
+  font: 400 16px Roboto;
+}
+
+.outgoing-call__subtitle-icon {
+  background: #a1a1a1;
+  height: 24px;
+  width: 24px;
+}
+```
+</Tab>
+</Tabs>
+
+#### avatarView
+
+<Frame>
+  <img src="/images/d242dfe4-outgoing_calls_avatar_view_web_screens-e4517aa9fc688283808448070a0d3c78.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatOutgoingCall, CometChatAvatar } from "@cometchat/chat-uikit-react";
+
+function OutgoingCallCustomAvatar({ call }: { call: CometChat.Call }) {
+  return (
+    <CometChatOutgoingCall
+      call={call}
+      avatarView={
+        <div className="outgoing-call__avatar">
+          <CometChatAvatar.Root
+            name={call.getCallReceiver()?.getName()}
+            image={(call.getCallReceiver() as CometChat.User)?.getAvatar()}
+          >
+            <CometChatAvatar.Image />
+            <CometChatAvatar.Initials />
+          </CometChatAvatar.Root>
+        </div>
+      }
+    />
+  );
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.outgoing-call__avatar .cometchat-avatar {
+  width: 160px;
+  height: 160px;
+  border-radius: 20px;
+}
+```
+</Tab>
+</Tabs>
 
 ### CSS Styling
 

--- a/ui-kit/react/components/search.mdx
+++ b/ui-kit/react/components/search.mdx
@@ -410,7 +410,215 @@ Use view props to replace sections of the default UI while keeping the component
 | `messageSubtitleView` | `(message) => ReactNode` | Subtitle of message result |
 | `messageTrailingView` | `(message) => ReactNode` | Trailing section of message result |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the search results */}
+#### messageItemView
+
+Replace the entire message list item in search results.
+
+<Frame>
+  <img src="/images/3d0a9273-search_message_item_view_custom_web_screens-bf216d1eab67d0d95362a3ef1996f752.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatSearch } from "@cometchat/chat-uikit-react";
+
+function SearchCustomMessageItem() {
+  const getMessageItemView = (message: CometChat.BaseMessage) => (
+    <div className="cometchat-search__message-list-item">
+      <div className="cometchat-search__message-list-item-sender">
+        {message.getSender()?.getName()}:
+      </div>
+      <div className="cometchat-search__message-list-item-text">
+        {message instanceof CometChat.TextMessage
+          ? (message as CometChat.TextMessage).getText()
+          : message.getType()}
+      </div>
+    </div>
+  );
+
+  return <CometChatSearch messageItemView={getMessageItemView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-search__message-list-item {
+  background: var(--cometchat-extended-primary-color-100);
+  border-bottom: 1px solid var(--cometchat-border-color-highlight);
+  padding: var(--cometchat-padding-3) var(--cometchat-padding-4);
+  display: flex;
+  justify-content: flex-start;
+  gap: var(--cometchat-padding-2);
+}
+
+.cometchat-search__message-list-item-sender {
+  color: var(--cometchat-text-color-highlight);
+  font: var(--cometchat-font-body-regular);
+}
+
+.cometchat-search__message-list-item-text {
+  color: var(--cometchat-text-color-secondary);
+  font: var(--cometchat-font-body-regular);
+}
+```
+</Tab>
+</Tabs>
+
+#### messageLeadingView
+
+Replace the message avatar / left section.
+
+<Frame>
+  <img src="/images/8ec51714-search_message_leading_view_custom_web_screens-af08d61c02454c807100907c1156d46d.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatSearch } from "@cometchat/chat-uikit-react";
+
+function SearchCustomMessageLeading() {
+  const getMessageLeadingView = (message: CometChat.BaseMessage) => (
+    <div className="cometchat-search__message-list-item-leading-view">
+      <img src="ICON_URL" alt="" />
+    </div>
+  );
+
+  return <CometChatSearch messageLeadingView={getMessageLeadingView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-search__message-list-item-leading-view {
+  height: 48px;
+  width: 48px;
+  border-radius: var(--cometchat-radius-2);
+  background: var(--cometchat-extended-primary-color-500);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cometchat-search__message-list-item-leading-view img {
+  height: 32px;
+  width: 32px;
+}
+```
+</Tab>
+</Tabs>
+
+#### messageTitleView
+
+Replace the message title text.
+
+<Frame>
+  <img src="/images/0b1cf07c-search_message_title_view_custom_web_screens-df6cb1c0e91a105d4f708e47c62de992.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatSearch } from "@cometchat/chat-uikit-react";
+
+function SearchCustomMessageTitle() {
+  const getMessageTitleView = (message: CometChat.BaseMessage) => (
+    <div className="cometchat-search__message-list-item-title">
+      <div className="cometchat-search__message-list-item-title-text">
+        {message.getSender()?.getName()}
+      </div>
+      <span>|</span>
+      <div className="cometchat-search__message-list-item-title-role">
+        {message.getSender().getRole() ?? "Pro User"}
+      </div>
+    </div>
+  );
+
+  return <CometChatSearch messageTitleView={getMessageTitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-search__message-list-item-title {
+  display: flex;
+  align-items: center;
+  gap: var(--cometchat-spacing-1);
+}
+
+.cometchat-search__message-list-item-title-text {
+  font: var(--cometchat-font-heading4-medium);
+  color: var(--cometchat-text-color-secondary);
+}
+
+.cometchat-search__message-list-item-title-role {
+  font: var(--cometchat-font-heading4-medium);
+  color: var(--cometchat-text-color-highlight);
+  text-decoration: underline;
+}
+```
+</Tab>
+</Tabs>
+
+#### messageSubtitleView
+
+Replace the message subtitle text.
+
+<Frame>
+  <img src="/images/67721bd7-search_message_subtitle_view_custom_web_screens-96e7a678fc3920eb12db00b43c4f6860.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatSearch } from "@cometchat/chat-uikit-react";
+
+function SearchCustomMessageSubtitle() {
+  const getMessageSubtitleView = (message: CometChat.BaseMessage) => (
+    <div className="cometchat-search__message-list-item-subtitle">
+      <div className="cometchat-search__message-list-item-subtitle-sender">
+        {message.getSender()?.getName()}:
+      </div>
+      <div className="cometchat-search__message-list-item-subtitle-text">
+        {message instanceof CometChat.TextMessage
+          ? (message as CometChat.TextMessage).getText()
+          : message.getType()}
+      </div>
+    </div>
+  );
+
+  return <CometChatSearch messageSubtitleView={getMessageSubtitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-search__message-list-item-subtitle {
+  background: var(--cometchat-extended-primary-color-100);
+  padding: var(--cometchat-padding-1);
+  display: flex;
+  justify-content: flex-start;
+  gap: var(--cometchat-padding-2);
+  width: 100%;
+}
+
+.cometchat-search__message-list-item-subtitle-sender {
+  color: var(--cometchat-text-color-highlight);
+  font: var(--cometchat-font-body-regular);
+}
+
+.cometchat-search__message-list-item-subtitle-text {
+  color: var(--cometchat-text-color-secondary);
+  font: var(--cometchat-font-body-regular);
+}
+```
+</Tab>
+</Tabs>
 
 ### Compound Composition
 

--- a/ui-kit/react/components/thread-header.mdx
+++ b/ui-kit/react/components/thread-header.mdx
@@ -285,7 +285,23 @@ Use view props to replace sections of the default UI while keeping the component
 | `messageBubbleView` | `ReactNode` | Parent message bubble |
 | `subtitleView` | `ReactNode` | Subtitle below the title |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the thread header */}
+#### messageBubbleView
+
+Replace the parent message bubble with a custom view.
+
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatThreadHeader } from "@cometchat/chat-uikit-react";
+
+function CustomBubbleThread({ parentMessage }: { parentMessage: CometChat.BaseMessage }) {
+  return (
+    <CometChatThreadHeader
+      parentMessage={parentMessage}
+      messageBubbleView={<div className="custom-bubble">Custom bubble view</div>}
+    />
+  );
+}
+```
 
 ### Compound Composition
 

--- a/ui-kit/react/components/users.mdx
+++ b/ui-kit/react/components/users.mdx
@@ -305,7 +305,265 @@ Use view props to replace sections of the default UI while keeping the component
 | `emptyView` | `ReactNode` | Empty state |
 | `errorView` | `ReactNode` | Error state |
 
-{/* TODO:IMAGE - Annotated diagram showing which view slot maps to which part of the user item */}
+#### itemView
+
+Replace the entire list item row.
+
+Default:
+
+<Frame>
+  <img src="/images/8a79367f-users_listItemView_default_web_screens-701c604eb9c2d04dcaa8013fe409fcd9.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/3e262fef-users_listItemView_custom_web_screens-e5bb179fd08dc3089f3f6c8a608a62d3.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatUsers } from "@cometchat/chat-uikit-react";
+
+function UsersDemo() {
+  const getItemView = (user: CometChat.User) => {
+    const status = user.getStatus();
+
+    return (
+      <div
+        className={`cometchat-users__list-item cometchat-users__list-item-${status}
+          ${status === "online" ? "cometchat-users__list-item-active" : ""}
+          `}
+      >
+        <span>{user.getName()}</span>
+        <span>{user.getStatus()}</span>
+      </div>
+    );
+  };
+
+  return <CometChatUsers itemView={getItemView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-users__list-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+}
+
+.cometchat-users__list-item-active {
+  background: rgba(9, 194, 111, 0.1);
+}
+```
+</Tab>
+</Tabs>
+
+#### leadingView
+
+Replace the avatar / left section.
+
+<Frame>
+  <img src="/images/f7433d40-users_leading_view-941e504d4acd9c4f23ccc7bc47d9f35e.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatUsers, CometChatAvatar } from "@cometchat/chat-uikit-react";
+
+function LeadingViewUsers() {
+  const getLeadingView = (user: CometChat.User) => {
+    return (
+      <div className="users__leading-view">
+        <CometChatAvatar.Root image={user.getAvatar()} name={user.getName()}>
+          <CometChatAvatar.Image />
+          <CometChatAvatar.Initials />
+        </CometChatAvatar.Root>
+      </div>
+    );
+  };
+
+  return <CometChatUsers leadingView={getLeadingView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.cometchat-users .users__leading-view .cometchat-avatar {
+  border-radius: 8px;
+  height: 48px;
+  width: 48px;
+}
+
+.users__leading-view {
+  position: relative;
+}
+```
+</Tab>
+</Tabs>
+
+#### titleView
+
+Replace the name / title text. Role badge inline example.
+
+<Frame>
+  <img src="/images/77ffdb3f-users_title_view-7f900436f6b63a3e9d3434b6e6e7a1bc.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatUsers } from "@cometchat/chat-uikit-react";
+
+function TitleViewUsers() {
+  const getTitleView = (user: CometChat.User) => {
+    return (
+      <div className="users__title-view">
+        <span className="users__title-view-name">{user.getName()}</span>
+        <span className="users__title-view-type">{user.getRole()}</span>
+      </div>
+    );
+  };
+
+  return <CometChatUsers titleView={getTitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.users__title-view {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  align-self: stretch;
+}
+
+.users__title-view-name {
+  overflow: hidden;
+  color: #141414;
+  text-overflow: ellipsis;
+  font: 500 16px Roboto;
+}
+
+.users__title-view-type {
+  color: #fff;
+  font: 600 8px Roboto;
+  display: flex;
+  height: 15px;
+  padding: 1px 3px;
+  justify-content: center;
+  align-items: center;
+  border-radius: 7px;
+  background: #09c26f;
+}
+```
+</Tab>
+</Tabs>
+
+#### subtitleView
+
+Replace the subtitle text for each user.
+
+Default:
+
+<Frame>
+  <img src="/images/03a38d40-users_subtitleView_default_web_screens-47bbbf7864a0f4c75fd99548ba54240e.png" />
+</Frame>
+
+Customized:
+
+<Frame>
+  <img src="/images/aa816f8e-users_subtitleView_custom_web_screens-d71b9197c2c12c7d4639c5cf917d1f20.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatUsers } from "@cometchat/chat-uikit-react";
+
+function SubtitleViewUsers() {
+  const getSubtitleView = (user: CometChat.User) => {
+    return (
+      <div className="users-subtitle">
+        {user.getStatusMessage() || user.getStatus()}
+      </div>
+    );
+  };
+
+  return <CometChatUsers subtitleView={getSubtitleView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.users-subtitle {
+  overflow: hidden;
+  color: #727272;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font: 400 14px Roboto;
+}
+```
+</Tab>
+</Tabs>
+
+#### trailingView
+
+Replace the right section.
+
+<Frame>
+  <img src="/images/58d37616-users_trailing_view-3e754b1f9546412d2ab768abe6bbe8aa.png" />
+</Frame>
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatUsers } from "@cometchat/chat-uikit-react";
+
+function TrailingViewUsers() {
+  const getTrailingView = (user: CometChat.User) => {
+    const tag = user.getTags()?.[0] ?? "";
+    return (
+      <div className="users__trailing-view">
+        <span className="users__trailing-view-text">{tag}</span>
+      </div>
+    );
+  };
+
+  return <CometChatUsers trailingView={getTrailingView} />;
+}
+```
+</Tab>
+<Tab title="CSS">
+```css
+.users__trailing-view {
+  display: flex;
+  width: 33px;
+  padding: 5px 3px;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 3px;
+  border-radius: 4px;
+  background: #6852d6;
+}
+
+.users__trailing-view-text {
+  font: 600 8px Inter;
+  color: white;
+}
+```
+</Tab>
+</Tabs>
 
 ### Compound Composition
 

--- a/ui-kit/react/theme/message-bubble-styling.mdx
+++ b/ui-kit/react/theme/message-bubble-styling.mdx
@@ -1,24 +1,87 @@
 ---
 title: "Message Bubble Styling"
-description: "Customize message bubble appearance including colors, borders, spacing, and alignment."
+description: "Customize incoming and outgoing message bubble colors, backgrounds, and styles using CSS variables and class selectors in the CometChat React UI Kit."
 ---
 
 <Accordion title="AI Integration Quick Reference">
 
 | Field | Value |
 | --- | --- |
-| Bubble wrapper class | `.cometchat-message-bubble` |
-| Incoming content | `.cometchat-message-bubble__content--incoming` |
-| Outgoing content | `.cometchat-message-bubble__content--outgoing` |
-| Key tokens | `--cometchat-neutral-color-300` (incoming bg), `--cometchat-primary-color` (outgoing bg) |
+| Goal | Customize message bubble appearance (colors, backgrounds) per direction and message type |
+| Where | `App.css` (global) — imported in app entry via `import "./App.css";` |
+| Base selector | `.cometchat .cometchat-message-bubble-(incoming\|outgoing) .cometchat-message-bubble__body` |
+| Type modifier | Append `.cometchat-message-bubble__<TYPE>-message` to target specific types (`text`, `image`, `video`, `audio`, `file`) |
+| Key tokens | `--cometchat-primary-color` (outgoing bg), `--cometchat-neutral-color-300` (incoming bg) |
+| Constraints | Global CSS only (no CSS Modules), no `!important`, type selectors override generic bubble selectors |
 
 </Accordion>
 
-## Overview
+Message bubble styling uses distinct CSS classes for incoming and outgoing messages. Each message type (text, image, video, audio, file, etc.) has predefined classes for default styling, customizable via CSS variable overrides.
 
-Message bubbles are the core visual element of the chat. This page covers how to customize their appearance — background colors, border radius, spacing, and text colors — using CSS variable overrides.
+<Warning>
+**Prerequisites before applying any CSS customization:**
+1. All selectors assume the UI Kit renders under a `.cometchat` root wrapper
+2. Import your CSS file at the app entry: `import "./App.css";` in `App.tsx`
+3. Use **global CSS** (not CSS Modules with hashed class names) — hashed selectors won't match
+</Warning>
 
-{/* TODO:IMAGE - Side-by-side comparison of default vs custom-styled bubbles */}
+---
+
+## Selector Pattern
+
+Use this table to construct the correct CSS selector for any message bubble target. AI agents should use this pattern to generalize — do not guess selectors.
+
+| Target | Selector Pattern |
+| --- | --- |
+| All bubbles | `.cometchat .cometchat-message-bubble .cometchat-message-bubble__body` |
+| Outgoing bubbles (all types) | `.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body` |
+| Incoming bubbles (all types) | `.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body` |
+| Specific type (outgoing) | `.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__<TYPE>-message` |
+| Specific type (incoming) | `.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__<TYPE>-message` |
+| Action bubbles (no direction) | `.cometchat .cometchat-message-bubble__body .cometchat-action-bubble` |
+
+<Note>
+
+`<TYPE>`
+
+`<TYPE>` is one of `text`, `image`, `video`, `audio`, `file`
+</Note>
+
+<Note>
+Link Preview Bubbles 
+
+It reuse the `text-message` type selector since link previews are rendered inside text messages.
+</Note>
+
+---
+
+## CSS Variable Reference
+
+These are the CSS variables (tokens) used across message bubble styling. This table tells you exactly what each token controls — do not assume a token affects something not listed here.
+
+| Variable | What It Controls | Default (Light) | Commonly Used On |
+| --- | --- | --- | --- |
+| `--cometchat-primary-color` | Outgoing bubble background, primary accent | `#6852d6` | Outgoing bubbles (all types), action bubble accent |
+| `--cometchat-neutral-color-300` | Incoming bubble background | `#E8E8E8` | Incoming bubbles (all types) |
+| `--cometchat-extended-primary-color-900` | Outgoing bubble shade/gradient variant | `#5d49be` | Outgoing text bubble, link preview |
+| `--cometchat-extended-primary-color-800` | Outgoing bubble secondary shade | `#5745b4` | Direct call outgoing bubble |
+| `--cometchat-extended-primary-color-700` | Outgoing bubble tertiary shade | `#4f3ea3` | Poll outgoing bubble |
+| `--cometchat-neutral-color-400` | Incoming bubble secondary shade | varies | Link preview incoming |
+| `--cometchat-primary-button-background` | Primary button fill inside bubbles | matches primary | Whiteboard/document incoming buttons |
+| `--cometchat-text-color-secondary` | Secondary/caption text color | varies | Action bubble text |
+| `--cometchat-icon-color-secondary` | Secondary icon color | varies | Action bubble icons |
+| `--cometchat-border-color-default` | Default border color | varies | Action bubble borders |
+
+---
+
+<Note>
+**CSS Specificity & Precedence Rules:**
+1. Message-type selectors (e.g., `__text-message`) override "All Message Bubbles" selectors
+2. Always keep the `.cometchat` prefix to avoid leaking styles into the host app
+3. Component-level variable overrides (`.cometchat-message-list { --var: val }`) override global overrides (`.cometchat { --var: val }`)
+4. CSS variable overrides only affect properties the UI Kit theme binds to that variable — they do NOT change layout or spacing
+5. `!important` should never be needed — if it is, your selector specificity is wrong
+</Note>
 
 ---
 
@@ -28,160 +91,866 @@ Each message bubble has this DOM structure:
 
 ```
 .cometchat-message-bubble
-  ├── .cometchat-message-bubble__leading (avatar)
-  ├── .cometchat-message-bubble__body
-  │   ├── .cometchat-message-bubble__header (sender name)
-  │   ├── .cometchat-message-bubble__reply (quoted message)
-  │   ├── .cometchat-message-bubble__content--incoming / --outgoing
-  │   │   └── (plugin bubble content: text, image, file, etc.)
-  │   ├── .cometchat-message-bubble__footer (reactions)
-  │   ├── .cometchat-message-bubble__status-info (timestamp + receipts)
-  │   └── .cometchat-message-bubble__thread (reply count)
-  └── .cometchat-message-bubble__bottom (moderation)
+  ├── .cometchat-message-bubble__leading-view (avatar)
+  ├── .cometchat-message-bubble__header-view (sender name)
+  ├── .cometchat-message-bubble__body-container
+  │   ├── .cometchat-message-bubble__body-wrapper
+  │   │   ├── .cometchat-message-bubble__body
+  │   │   │   ├── .cometchat-message-bubble__body-reply-view (quoted message)
+  │   │   │   ├── .cometchat-message-bubble__body-content-view (plugin bubble content)
+  │   │   │   └── .cometchat-message-bubble__body-status-info-view (timestamp + receipts)
+  │   │   ├── .cometchat-message-bubble__body-footer-view (reactions)
+  │   │   ├── .cometchat-message-bubble__body-thread-view (reply count)
+  │   │   └── .cometchat-message-bubble__body-bottom-view (moderation)
+  │   └── .cometchat-message-bubble__options (context menu)
 ```
 
 ---
 
-## Customizing Bubble Colors
+## Incoming & Outgoing Messages
 
-### Incoming Bubble Background
+Incoming and outgoing messages have different styling by default, allowing users to visually separate their own messages from others'. Here, we show both the default view and examples of customizations for these message bubbles.
 
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/82088b57-message_bubble_styling_default-b1a15eb68fcf1e9a68296ccdd1aa8488.png" />
+</Frame>
+
+***
+
+### Styling
+
+#### Outgoing Message Bubbles
+
+**Selectors:**
 ```css
-.cometchat-message-bubble__content--incoming {
-  background: #f0f0f0;
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body
+```
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Outgoing bubble background |
+| `--cometchat-extended-primary-color-900` | Outgoing bubble shade |
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/eb47fdb7-message_bubble_styling_custom_outgoing_bubbles-a58b5baf50e3f6784c1dd4443ade5419.png" />
+</Frame>
+
+Use the following code to achieve the customization shown above.
+
+```css title="App.css"
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body {
+  --cometchat-primary-color: #f76808;
+  --cometchat-extended-primary-color-900: #fbaa75;
 }
 ```
 
-### Outgoing Bubble Background
+**Expected result:** All outgoing message bubbles change from purple to orange (#f76808) with a lighter orange shade (#fbaa75).
 
+***
+
+#### Incoming Message Bubbles
+
+**Selectors:**
 ```css
-.cometchat-message-bubble__content--outgoing {
-  background: #6852d6;
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body
+```
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-neutral-color-300` | Incoming bubble background |
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/f80a1ad4-message_bubble_styling_custom_incoming_bubbles-7b0644cba17d6148e15d7ab70124901c.png" />
+</Frame>
+
+Use the following code to achieve the customization shown above.
+
+```css title="App.css"
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body {
+  --cometchat-neutral-color-300: #f76808;
 }
 ```
 
-### Using CSS Variables (Recommended)
+**Expected result:** All incoming message bubbles change from white/light to orange (#f76808).
 
-Override the tokens on `.cometchat` — this is the simplest and most reliable approach:
+***
 
+#### All Message Bubbles
+
+**Selectors:**
 ```css
-.cometchat {
-  /* Incoming bubble background */
-  --cometchat-neutral-color-300: #e3f2fd;
+.cometchat .cometchat-message-bubble .cometchat-message-bubble__body
+```
 
-  /* Outgoing bubble background (uses primary color) */
-  --cometchat-primary-color: #1976d2;
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-neutral-color-300` | Incoming bubble background |
+| `--cometchat-primary-color` | Outgoing bubble background |
+| `--cometchat-extended-primary-color-900` | Outgoing bubble shade |
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/e5b849ed-message_bubble_styling_custom_all_bubbles-525099af213cddef662fb77ac0398710.png" />
+</Frame>
+
+Use the following code to achieve the customization shown above.
+
+```css title="App.css"
+.cometchat .cometchat-message-bubble .cometchat-message-bubble__body {
+  --cometchat-neutral-color-300: #f76808;
+  --cometchat-primary-color: #f76808;
+  --cometchat-extended-primary-color-900: #fbaa75;
 }
 ```
+
+**Expected result:** Both incoming and outgoing bubbles use orange (#f76808), with outgoing shade set to lighter orange (#fbaa75).
+
+***
+
+### Complete End-to-End Example
+
+To apply custom bubble colors in your app:
+
+**Step 1:** Add to `App.css`:
+
+```css
+/* Custom outgoing bubbles */
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body {
+  --cometchat-primary-color: #f76808;
+  --cometchat-extended-primary-color-900: #fbaa75;
+}
+
+/* Custom incoming bubbles */
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body {
+  --cometchat-neutral-color-300: #feede1;
+}
+```
+
+**Step 2:** Ensure `App.tsx` imports the CSS:
+
+```tsx
+import "./App.css";
+// ... render CometChat UI Kit components
+```
+
+**Expected result:** Outgoing bubbles use orange (#f76808) with lighter shade (#fbaa75); incoming bubbles use light peach (#feede1).
+
+***
+
+## Message Types
+
+CometChat UI Kit includes classes for various message types. Below are examples of default & customised views for each message type, along with the relevant CSS code snippets so that you can quickly get up to speed with CSS customization.
+
+***
+
+### Text Message Bubble
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
+```css
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__text-message
+```
+</Tab>
+<Tab title="Incoming">
+```css
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__text-message
+```
+</Tab>
+</Tabs>
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Outgoing text bubble background |
+| `--cometchat-neutral-color-300` | Incoming text bubble background |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/fa4eb398-text_message_bubble_default-e20a1cae931c771c1cc0db796dbd292d.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/23809d0d-text_message_bubble_custom-6658691cdd69e6eba64a73041b4de005.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
+```css
+/* Outgoing Text Message Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-primary-color: #f76808;
+}
+
+/* Incoming Text Message Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-neutral-color-300: #feede1;
+}
+```
+</Tab>
+</Tabs>
+
+**Expected result:** Outgoing text bubbles change to orange (#f76808); incoming text bubbles change to light peach (#feede1).
+
+***
+
+### Image Message Bubble
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
+```css
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__image-message
+```
+</Tab>
+<Tab title="Incoming">
+```css
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__image-message
+```
+</Tab>
+</Tabs>
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Outgoing image bubble background |
+| `--cometchat-neutral-color-300` | Incoming image bubble background |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/cd898026-image_message_bubble_default-7918ea21eae55cd008eff6a567fec19a.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/90eaeef4-image_message_bubble_custom-864b9cc63443a30a4830d84b96d9da1e.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
+```css
+/* Outgoing Image Message Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__image-message {
+  --cometchat-primary-color: #f76808;
+}
+
+/* Incoming Image Message Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__image-message {
+  --cometchat-neutral-color-300: #feede1;
+}
+```
+</Tab>
+</Tabs>
+
+**Expected result:** Outgoing image bubbles change to orange (#f76808); incoming image bubbles change to light peach (#feede1).
+
+***
+
+### Video Message Bubble
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
+```css
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__video-message
+```
+</Tab>
+<Tab title="Incoming">
+```css
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__video-message
+```
+</Tab>
+</Tabs>
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Outgoing video bubble background |
+| `--cometchat-neutral-color-300` | Incoming video bubble background |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/bc8adc5d-video_message_bubble_default-b159e925e6598e5b01e4d9a2490e0d4c.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/9cc7c4d6-video_message_bubble_custom-2c1fcd569de35d4ad7b83641bd68b9e0.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
+```css
+/* Outgoing Video Message Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__video-message {
+  --cometchat-primary-color: #f76808;
+}
+
+/* Incoming Video Message Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__video-message {
+  --cometchat-neutral-color-300: #feede1;
+}
+```
+</Tab>
+</Tabs>
+
+**Expected result:** Outgoing video bubbles change to orange (#f76808); incoming video bubbles change to light peach (#feede1).
+
+***
+
+### Audio Message Bubble
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
+```css
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__audio-message
+```
+</Tab>
+<Tab title="Incoming">
+```css
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__audio-message
+```
+</Tab>
+</Tabs>
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Outgoing audio bubble background, incoming audio accent |
+| `--cometchat-neutral-color-300` | Incoming audio bubble background |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/a4a1b992-audio_message_bubble_default-970bc6bcea3c589a44f649c47b9c04a4.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/21bb54b1-audio_message_bubble_custom-68c7ca1b576d7aed709d1e3ef80e371a.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
+```css
+/* Outgoing Audio Message Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__audio-message {
+  --cometchat-primary-color: #f76808;
+}
+
+/* Incoming Audio Message Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__audio-message {
+  --cometchat-primary-color: #f76808;
+  --cometchat-neutral-color-300: #feede1;
+}
+```
+</Tab>
+</Tabs>
+
+**Expected result:** Outgoing audio bubbles change to orange (#f76808); incoming audio bubbles change to light peach (#feede1) with orange accent for playback controls.
+
+***
+
+### File Message Bubble
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
+```css
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__file-message
+```
+</Tab>
+<Tab title="Incoming">
+```css
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__file-message
+```
+</Tab>
+</Tabs>
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Outgoing file bubble background, incoming file accent |
+| `--cometchat-neutral-color-300` | Incoming file bubble background |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/2743e926-file_message_bubble_default-032205256a207879384943fc87367b03.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/35dad07f-file_message_bubble_custom-e4661d6df1324ab28b8b2de991477f12.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
+```css
+/* Outgoing File Message Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__file-message {
+  --cometchat-primary-color: #f76808;
+}
+
+/* Incoming File Message Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__file-message {
+  --cometchat-primary-color: #f76808;
+  --cometchat-neutral-color-300: #feede1;
+}
+```
+</Tab>
+</Tabs>
+
+**Expected result:** Outgoing file bubbles change to orange (#f76808); incoming file bubbles change to light peach (#feede1) with orange file icon accent.
+
+***
+
+### Action Message Bubble
+
+Action messages (e.g., "User joined the group") use a different selector pattern — they are not directional (no incoming/outgoing).
+
+**Selector:**
+- `.cometchat .cometchat-message-bubble__body .cometchat-action-bubble`
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Action bubble accent color |
+| `background-color` | Action bubble background (direct CSS property, not a variable) |
+| `--cometchat-text-color-secondary` | Action bubble text color |
+| `--cometchat-icon-color-secondary` | Action bubble icon color |
+| `--cometchat-border-color-default` | Action bubble border color |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/a2c4c9a6-wcXOfMpnNl0mgAAAABJRU5ErkJggg.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/2d6c38a0-action_message_bubble_custom-160bec68a93f3aca25e473bb60886649.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
+```css
+.cometchat .cometchat-message-bubble__body .cometchat-action-bubble {
+  --cometchat-primary-color: #f76808;
+  background-color: #feede1;
+  --cometchat-text-color-secondary: #f76808;
+  --cometchat-icon-color-secondary: #f76808;
+  --cometchat-border-color-default: #f76808;
+}
+```
+</Tab>
+</Tabs>
+
+**Expected result:** Action message banners change to light peach background (#feede1) with orange text, icons, and borders (#f76808).
+
+***
+
+### Extensions
+
+#### Collaborative Whiteboard Bubble
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
+```css
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__text-message
+```
+</Tab>
+<Tab title="Incoming">
+```css
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__text-message
+```
+</Tab>
+</Tabs>
 
 <Note>
-Changing `--cometchat-neutral-color-300` affects all elements that use it (borders, dividers, etc.), not just bubbles. For bubble-only changes, use the attribute selector approach or wrap the message list in your own class.
+In v7, collaborative whiteboard messages use the `text-message` type class internally.
 </Note>
 
----
+**Tokens used:**
 
-## Customizing Bubble Shape
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Bubble accent and background |
+| `--cometchat-primary-button-background` | Incoming whiteboard "Open" button fill |
+| `--cometchat-neutral-color-300` | Incoming bubble background |
 
-### Border Radius
+Shown below is the default chat interface.
 
+<Frame>
+  <img src="/images/cbb18dd6-extensions_whiteboard_message_bubble_default-51119b88b5b6bc11b4628d2d03b6c0a4.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/3470b5c8-extensions_whiteboard_message_bubble_custom-005a48db24137a2870f4933afa07835d.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
 ```css
-.cometchat-message-bubble__content--incoming,
-.cometchat-message-bubble__content--outgoing {
-  border-radius: 16px;
+/* Outgoing Collaborative Whiteboard Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-primary-color: #f76808;
+}
+
+/* Incoming Collaborative Whiteboard Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-primary-color: #f76808;
+  --cometchat-primary-button-background: #f76808;
+  --cometchat-neutral-color-300: #feede1;
 }
 ```
+</Tab>
+</Tabs>
 
-### Remove Rounded Corners
+**Expected result:** Outgoing whiteboard bubbles change to orange (#f76808); incoming whiteboard bubbles change to light peach (#feede1) with orange button and accent.
 
+***
+
+#### Collaborative Document Bubble
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
 ```css
-.cometchat-message-bubble__content--incoming,
-.cometchat-message-bubble__content--outgoing {
-  border-radius: 0;
-}
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__text-message
 ```
-
----
-
-## Customizing Bubble Spacing
-
-### Gap Between Bubbles
-
+</Tab>
+<Tab title="Incoming">
 ```css
-.cometchat-message-bubble {
-  margin-bottom: 16px;
-}
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__text-message
 ```
+</Tab>
+</Tabs>
 
-### Content Padding
+<Note>
+In v7, collaborative document messages use the `text-message` type class internally.
+</Note>
 
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Bubble accent and background |
+| `--cometchat-primary-button-background` | Incoming document "Open" button fill |
+| `--cometchat-neutral-color-300` | Incoming bubble background |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/83da2542-extensions_document_message_bubble_default-834f3b0a25f728f04167ab1fcbfff6a2.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/a2d29f42-extensions_document_message_bubble_custom-9cffd5b18fd7d7e675552fd116c21b71.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
 ```css
-.cometchat-message-bubble__content--incoming,
-.cometchat-message-bubble__content--outgoing {
-  padding: 12px 16px;
+/* Outgoing Collaborative Document Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-primary-color: #f76808;
+}
+
+/* Incoming Collaborative Document Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-primary-color: #f76808;
+  --cometchat-primary-button-background: #f76808;
+  --cometchat-neutral-color-300: #feede1;
 }
 ```
+</Tab>
+</Tabs>
 
----
+**Expected result:** Outgoing document bubbles change to orange (#f76808); incoming document bubbles change to light peach (#feede1) with orange button and accent.
 
-## Customizing Text Colors
+***
 
-### Incoming Message Text
+#### Polls Bubble
 
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
 ```css
-.cometchat-text-bubble--incoming {
-  color: #333333;
-}
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__text-message
 ```
-
-### Outgoing Message Text
-
+</Tab>
+<Tab title="Incoming">
 ```css
-.cometchat-text-bubble--outgoing {
-  color: #ffffff;
-}
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__text-message
 ```
+</Tab>
+</Tabs>
 
----
+<Note>
+In v7, poll messages use the `text-message` type class internally.
+</Note>
 
-## Customizing Timestamp & Receipts
+**Tokens used:**
 
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Bubble accent and background |
+| `--cometchat-extended-primary-color-700` | Outgoing poll progress bar shade |
+| `--cometchat-neutral-color-300` | Incoming bubble background |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/f1c7a340-extensions_poll_message_bubble_default-9a10c3c038456c4e6c567b24892eff3f.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/58f52202-extensions_poll_message_bubble_custom-5deaab680a3ed80d5b1761099313ac26.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
 ```css
-.cometchat-message-bubble__status-info {
-  font-size: 11px;
-  color: #999999;
+/* Outgoing Poll Message Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-primary-color: #f76808;
+  --cometchat-extended-primary-color-700: #fbaa75;
+}
+
+/* Incoming Poll Message Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-primary-color: #f76808;
+  --cometchat-neutral-color-300: #feede1;
 }
 ```
+</Tab>
+</Tabs>
 
----
+**Expected result:** Outgoing poll bubbles change to orange (#f76808) with lighter progress bars (#fbaa75); incoming poll bubbles change to light peach (#feede1) with orange accent.
 
-## Full Example: Custom Bubble Theme
+***
 
-```css title="src/bubble-overrides.css"
-/* Rounded bubbles with custom colors */
-.cometchat-message-bubble__content--incoming {
-  background: #e8f5e9;
-  border-radius: 18px 18px 18px 4px;
+#### Stickers Bubble
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
+```css
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__image-message
+```
+</Tab>
+<Tab title="Incoming">
+```css
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__image-message
+```
+</Tab>
+</Tabs>
+
+<Note>
+In v7, sticker messages use the `image-message` type class internally.
+</Note>
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Outgoing sticker bubble background |
+| `--cometchat-neutral-color-300` | Incoming sticker bubble background |
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/ca08378b-extensions_sticker_message_bubble_default-0f8dc6633998822ecd25199af799b2ad.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/e64d8a88-extensions_sticker_message_bubble_custom-857ab9cc16e651b907e8f03293e403be.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
+```css
+/* Outgoing Sticker Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__image-message {
+  --cometchat-primary-color: #f76808;
 }
 
-.cometchat-message-bubble__content--outgoing {
-  background: #1b5e20;
-  border-radius: 18px 18px 4px 18px;
-}
-
-.cometchat-text-bubble--incoming {
-  color: #1b5e20;
-}
-
-.cometchat-text-bubble--outgoing {
-  color: #ffffff;
-}
-
-/* Smaller timestamp */
-.cometchat-message-bubble__status-info {
-  font-size: 10px;
-  opacity: 0.7;
+/* Incoming Sticker Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__image-message {
+  --cometchat-neutral-color-300: #feede1;
 }
 ```
+</Tab>
+</Tabs>
+
+**Expected result:** Outgoing sticker bubbles change to orange (#f76808); incoming sticker bubbles change to light peach (#feede1).
+
+***
+
+#### Link Preview Bubble
+
+Link previews render inside text message bubbles, so they use the `text-message` type selector.
+
+**Selectors:**
+<Tabs>
+<Tab title="Outgoing">
+```css
+.cometchat .cometchat-message-bubble-outgoing .cometchat-message-bubble__body.cometchat-message-bubble__text-message
+```
+</Tab>
+<Tab title="Incoming">
+```css
+.cometchat .cometchat-message-bubble-incoming .cometchat-message-bubble__body.cometchat-message-bubble__text-message
+```
+</Tab>
+</Tabs>
+
+**Tokens used:**
+
+| Token | Controls |
+| --- | --- |
+| `--cometchat-primary-color` | Outgoing link preview bubble background |
+| `--cometchat-extended-primary-color-900` | Outgoing link preview shade |
+| `--cometchat-neutral-color-400` | Incoming link preview secondary shade |
+| `--cometchat-neutral-color-300` | Incoming link preview bubble background |
+
+<Note>
+Styling link preview bubbles also affects regular text message bubbles since they share the same `__text-message` selector. This is by design — link previews are a sub-feature of text messages.
+</Note>
+
+Shown below is the default chat interface.
+
+<Frame>
+  <img src="/images/28503268-extensions_link_preview_message_bubble_default-35dcf065866790a1e388c021a68188b0.png" />
+</Frame>
+
+The customized chat interface is displayed below.
+
+<Frame>
+  <img src="/images/4a2aa81e-extensions_link_preview_message_bubble_custom-a79d83c32cc6946d1c35c1803821fe3e.png" />
+</Frame>
+
+**Complete CSS:**
+
+<Tabs>
+<Tab title="App.css">
+```css
+/* Outgoing Link Preview Bubble */
+.cometchat
+  .cometchat-message-bubble-outgoing
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-primary-color: #f76808;
+  --cometchat-extended-primary-color-900: #fbaa75;
+}
+
+/* Incoming Link Preview Bubble */
+.cometchat
+  .cometchat-message-bubble-incoming
+  .cometchat-message-bubble__body.cometchat-message-bubble__text-message {
+  --cometchat-neutral-color-400: #fbaa75;
+  --cometchat-neutral-color-300: #feede1;
+}
+```
+</Tab>
+</Tabs>
+
+**Expected result:** Outgoing link preview bubbles change to orange (#f76808) with lighter shade (#fbaa75); incoming link preview bubbles change to light peach (#feede1) with orange secondary shade (#fbaa75).
 
 ---
 
@@ -192,16 +961,22 @@ Class names are plain, stable BEM names that you can target directly:
 | Target | Selector |
 | --- | --- |
 | Bubble wrapper | `.cometchat-message-bubble` |
-| Leading (avatar) | `.cometchat-message-bubble__leading` |
+| Leading view (avatar) | `.cometchat-message-bubble__leading-view` |
+| Header view (sender name) | `.cometchat-message-bubble__header-view` |
+| Sender name | `.cometchat-message-bubble__sender-name` |
+| Body container | `.cometchat-message-bubble__body-container` |
+| Body wrapper | `.cometchat-message-bubble__body-wrapper` |
 | Body | `.cometchat-message-bubble__body` |
-| Header (sender name) | `.cometchat-message-bubble__header` |
-| Reply preview | `.cometchat-message-bubble__reply` |
-| Content (incoming) | `.cometchat-message-bubble__content--incoming` |
-| Content (outgoing) | `.cometchat-message-bubble__content--outgoing` |
-| Footer (reactions) | `.cometchat-message-bubble__footer` |
-| Status info (time + receipts) | `.cometchat-message-bubble__status-info` |
-| Thread indicator | `.cometchat-message-bubble__thread` |
-| Bottom (moderation) | `.cometchat-message-bubble__bottom` |
+| Reply view (quoted message) | `.cometchat-message-bubble__body-reply-view` |
+| Content view | `.cometchat-message-bubble__body-content-view` |
+| Status info (time + receipts) | `.cometchat-message-bubble__body-status-info-view` |
+| Footer (reactions) | `.cometchat-message-bubble__body-footer-view` |
+| Thread indicator | `.cometchat-message-bubble__body-thread-view` |
+| Bottom (moderation) | `.cometchat-message-bubble__body-bottom-view` |
+| Options (context menu) | `.cometchat-message-bubble__options` |
+| Incoming direction | `.cometchat-message-bubble-incoming` |
+| Outgoing direction | `.cometchat-message-bubble-outgoing` |
+| Action message | `.cometchat-message-bubble-action` |
 
 <Note>
 All class names follow BEM conventions and are stable across builds. You can target them with standard `.class-name` selectors in your CSS.


### PR DESCRIPTION
## Summary

- Added view slot examples with images and code blocks to 11 component docs (conversations, groups, users, group-members, ai-assistant-chat, message-header, message-list, message-composer, incoming-call, outgoing-call, search, thread-header)
- Replaced TODO:IMAGE placeholders with actual view slot demonstrations from v6, adapted for v7 architecture
- Replaced CSS Selectors section with full CSS Architecture section in conversations.mdx
- Rewrote message-bubble-styling.mdx to match v6 structure with all message type examples
- Removed unsupported options prop from conversations docs

## V7 Architecture Adaptations

- No separate CSS import (styles bundled automatically)
- CometChatAvatar/Button/Date use compound component pattern
- useLocale() hook instead of getLocalizedString
- useLoggedInUser() hook instead of CometChatUIKitLoginListener
- Plain objects for options instead of CometChatOption class
- CometChatListItem not publicly exported