### PR TITLE
Add loadLastAgentConversation to iOS UI Kit message-list AI Features

### DIFF
--- a/ui-kit/ios/message-list.mdx
+++ b/ui-kit/ios/message-list.mdx
@@ -977,6 +977,61 @@ let messageList = CometChatMessageList()
 messageList.set(smartRepliesDelayDuration: 2.0)
 ```
 
+### loadLastAgentConversation
+
+When chatting with an AI agent, this property controls whether the message list loads the most recent existing conversation or starts fresh.
+
+| | |
+|---|---|
+| Type | `Bool` |
+| Default | `false` |
+
+**Basic usage — just enable the property:**
+
+```swift
+let messageList = CometChatMessageList()
+messageList.set(user: aiAgentUser)
+messageList.set(loadLastAgentConversation: true)
+```
+
+**Full setup with composer continuation:**
+
+```swift
+// In your messages view controller:
+let messageList = CometChatMessageList()
+messageList.set(user: aiAgentUser)
+messageList.set(loadLastAgentConversation: true)
+
+let composer = CometChatMessageComposer()
+composer.set(user: aiAgentUser)
+
+// Wire the callback so the composer knows which thread to continue
+messageList.onLastAgentConversationLoaded = { parentMessageId in
+    composer.set(parentMessageId: parentMessageId)
+}
+```
+
+**Handling "New Chat" vs "Load Previous":**
+
+```swift
+// Opening from conversations list → loads previous conversation
+messageList.set(loadLastAgentConversation: true)
+
+// "New Chat" button → always starts fresh
+messageList.set(loadLastAgentConversation: false)
+
+// Chat History → opens specific thread (use parentMessage directly)
+messageList.set(user: aiAgentUser, parentMessage: selectedMessage, withParent: true)
+```
+
+**Behavior matrix:**
+
+| `loadLastAgentConversation` | Previous conversation exists? | Result |
+| --------------------------- | ----------------------------- | ------ |
+| `false` (default) | — | Fresh AI greeting + suggestions |
+| `true` | Yes | Loads most recent thread |
+| `true` | No | Falls back to fresh AI greeting |
+
 ---
 
 ## Reactions Configuration


### PR DESCRIPTION
## Description

Controls whether the message list loads the user's most recent conversation with an AI agent or starts a new chat. When enabled, the latest existing AI conversation is restored (if available); otherwise, the component falls back to a fresh conversation experience. This is useful for providing chat continuity across sessions.

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [ ] Documentation correction/update
- [ ] New documentation
- [x] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
