### PR TITLE
docs(ui-kit/react): remove loggedInUser prop from v7 MessageList migration reference

### DIFF
--- a/ui-kit/react/migration-property-changes.mdx
+++ b/ui-kit/react/migration-property-changes.mdx
@@ -68,7 +68,6 @@ These 8 patterns apply across all components. You do not need to look them up pe
 
 | Prop | Type | Description |
 | --- | --- | --- |
-| `loggedInUser` | `CometChat.User` | Override the logged-in user |
 | `messageTypes` | `string[]` | Filter message types to display |
 | `messageCategories` | `string[]` | Filter message categories |
 | `onAvatarClick` | `(user: CometChat.User) => void` | Avatar click callback |


### PR DESCRIPTION
## Description

- Remove the `loggedInUser` prop from the `CometChatMessageList` "New Props" table in the v7 migration property-changes reference. In v7 this prop is no longer surfaced as a public `CometChatMessageList` prop, so documenting it under added props was inaccurate.

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [x] Documentation correction/update
- [ ] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

Verified that no v7 code snippet passes `loggedInUser` as a prop to any component. Remaining references to `loggedInUser` in the v7 docs are unrelated and intentionally left in place: the `getLoggedInUser()` method, the `useLoggedInUser()` hook, the `bubbleView` render-prop's second argument, and the `PluginContext.loggedInUser` field.

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
