### PR TITLE
fix: correct "extension" references in SendGrid email setup

### DIFF
--- a/notifications/email-custom-providers.mdx
+++ b/notifications/email-custom-providers.mdx
@@ -21,7 +21,7 @@ Authorization: Basic <Base64-encoded-credentials>
 2. Enable the provider.
 3. Enter the publicly accessible webhook URL.
 4. (Recommended) Enable Basic Authentication and set username/password.
-5. Decide if you want to **Trigger only if email address is stored with CometChat** (via [Update Contact details API](/rest-api/chat-apis)); when off, the webhook fires regardless.
+5. Decide if you want to **Trigger only if email address is stored with CometChat** (via [Update Contact details API](/rest-api/notifications-apis/push/update-contact-details)); when off, the webhook fires regardless.
 6. Save the credentials.
 
 <Frame>
@@ -52,7 +52,7 @@ Example: if a group has 100 members, your webhook receives 100 POSTs.
           "avatar": "https://assets.cometchat.io/sampleapp/v2/users/cometchat-uid-4.webp",
           "name": "Susan Marie"
         },
-        "message": "Are we meeting on this weekend?",
+        "message": "Are we meeting this weekend?",
         "messageObject": {CometChat Message Object}, // Present if "Include message object" is enabled. The message object is present for new messages or in case a message was edited
       },
       {

--- a/notifications/email-integration.mdx
+++ b/notifications/email-integration.mdx
@@ -12,7 +12,7 @@ Connect CometChat email notifications to SendGrid or your own provider, wire the
 
 ## SendGrid setup
 
-We have partnered with SendGrid for sending Email Notifications and hence you need to set up an account on [SendGrid](https://www.sendgrid.com/) before you start using the extension.
+We have partnered with SendGrid for sending Email Notifications and hence you need to set up an account on [SendGrid](https://www.sendgrid.com/) before you start using this integration.
 
 ### 1. Get your SendGrid API key
 
@@ -35,7 +35,7 @@ We have partnered with SendGrid for sending Email Notifications and hence you ne
 9. Enter the Version name and the value for Subject as `{{subject}}` and hit "Save".
 10. You have now successfully created a Template with a version.
 11. From the Dynamic Templates listing page, expand your Template and make a note of the **Template ID** for later use.
-12. The payload sent by the extension to SendGrid is as follows:
+12. The payload sent to SendGrid is as follows:
 
 <Tabs>
 <Tab title="For one-on-one conversation">

--- a/notifications/email-integration.mdx
+++ b/notifications/email-integration.mdx
@@ -54,7 +54,7 @@ We have partnered with SendGrid for sending Email Notifications and hence you ne
         "avatar": "https://assets.cometchat.io/sampleapp/v2/users/cometchat-uid-4.webp",
         "name": "Susan Marie"
       },
-      "message": "Are we meeting on this weekend?",
+      "message": "Are we meeting this weekend?",
       "messageObject": {CometChat Message Object}, // Present if "Include message object" is enabled. The message object is present for new messages or in case a message was edited
     },
     {
@@ -365,7 +365,7 @@ An unsubscribe group will allow your users to unsubscribe to only chat email not
 
 ### 4. Store contact details
 
-Store each user's contact email/phone with the [Update Contact details API](/rest-api/chat-apis). Use the user's UID in `onBehalfOf` and call the region-specific base URL (`api-us`, `api-eu`, `api-in`).
+Store each user's contact email/phone with the [Update Contact details API](/rest-api/notifications-apis/push/update-contact-details). Use the user's UID in `onBehalfOf` and call the region-specific base URL (`api-us`, `api-eu`, `api-in`).
 
 Example request:
 
@@ -409,13 +409,13 @@ Save the following details:
 
 <Note>
 
-The domain used in Sender's Email needs to be Authenticated. Refer to SendGrid's documentation on [Domain Authentication](https://docs.sendgrid.com/ui/account-and-settings/how-to-set-up-domain-authentication) for more details. Use the complete authenticated domain in the sender's email address. For eg, if your domain is example.com and the authenticated domain is em1235.example.com, then the sender's email address should be [sender@em1235.example.com](mailto:sender@em1235.example.com) and not [sender@example.com](mailto:sender@example.com)
+The domain used in Sender's Email needs to be Authenticated. Refer to SendGrid's documentation on [Domain Authentication](https://docs.sendgrid.com/ui/account-and-settings/how-to-set-up-domain-authentication) for more details. Use the complete authenticated domain in the sender's email address. For example, if your domain is example.com and the authenticated domain is em1235.example.com, then the sender's email address should be [sender@em1235.example.com](mailto:sender@em1235.example.com) and not [sender@example.com](mailto:sender@example.com)
 
 </Note>
 
 ### 7. Save user timezones
 
-A user's timezone is required to allow them to set a schedule for receiving notifications. In case the timezone is not registered, the default timezone for
+A user's timezone is required to allow them to set a schedule for receiving notifications. In case the timezone is not registered, the default timezone for the region is used:
 
 * For US region: EST
 * For EU region: GMT
@@ -446,7 +446,7 @@ Send a message to any user and keep the conversation unread for the designated a
 
 ### 9. Configure email replies (optional)
 
-In the SendGrid provider settings, enable the email replies. Optionally, you can set a different sender's email address. Only ensure that the it doesn't contain any "+" symbol in it.
+In the SendGrid provider settings, enable the email replies. Optionally, you can set a different sender's email address. Just ensure that it doesn't contain any "+" symbol.
 
 Copy the Replies webhook URL as that will be required for Inbound parse configuration on SendGrid's end. Follow the [SendGrid's Inbound parse webhook](https://www.twilio.com/docs/sendgrid/for-developers/parsing-email/setting-up-the-inbound-parse-webhook) steps.
 


### PR DESCRIPTION
Email notifications are a native integration, not an extension. Updated the SendGrid setup section to remove the two inaccurate "extension" mentions.

## Description

<!-- Please include a summary of the changes and relevant context. -->

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [x] Documentation correction/update
- [ ] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [ ] All links in my changes are valid and working
- [ ] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
