### PR TITLE
docs(ai-agent): reflect group conversation support in v6 Android AI Agent guide

### DIFF
--- a/ui-kit/android/v6/call-features.mdx
+++ b/ui-kit/android/v6/call-features.mdx
@@ -33,8 +33,8 @@ Add the following dependency to your `build.gradle.kts` file:
 <Tab title="Kotlin (XML Views)">
 ```kotlin build.gradle.kts
 dependencies {
-    implementation("com.cometchat:chatuikit-kotlin-android:6.0.0")
-    implementation("com.cometchat:calls-sdk-android:5.0.0-beta.2")
+    implementation("com.cometchat:chatuikit-kotlin-android:6.0.3")
+    implementation("com.cometchat:calls-sdk-android:5.0.1")
 }
 ```
 </Tab>
@@ -42,8 +42,8 @@ dependencies {
 <Tab title="Jetpack Compose">
 ```kotlin build.gradle.kts
 dependencies {
-    implementation("com.cometchat:chatuikit-compose-android:6.0.0")
-    implementation("com.cometchat:calls-sdk-android:5.0.0-beta.2")
+    implementation("com.cometchat:chatuikit-compose-android:6.0.3")
+    implementation("com.cometchat:calls-sdk-android:5.0.1")
 }
 ```
 </Tab>

--- a/ui-kit/android/v6/calling-integration.mdx
+++ b/ui-kit/android/v6/calling-integration.mdx
@@ -19,8 +19,8 @@ Add the CometChat Calls SDK dependency alongside your chosen UI Kit module:
 <Tab title="Kotlin (XML Views)">
 ```kotlin build.gradle.kts
 dependencies {
-    implementation("com.cometchat:chatuikit-kotlin-android:6.0.0")
-    implementation("com.cometchat:calls-sdk-android:5.0.0-beta.2")
+    implementation("com.cometchat:chatuikit-kotlin-android:6.0.3")
+    implementation("com.cometchat:calls-sdk-android:5.0.1")
 }
 ```
 </Tab>
@@ -28,8 +28,8 @@ dependencies {
 <Tab title="Jetpack Compose">
 ```kotlin build.gradle.kts
 dependencies {
-    implementation("com.cometchat:chatuikit-compose-android:6.0.0")
-    implementation("com.cometchat:calls-sdk-android:5.0.0-beta.2")
+    implementation("com.cometchat:chatuikit-compose-android:6.0.3")
+    implementation("com.cometchat:calls-sdk-android:5.0.1")
 }
 ```
 </Tab>

--- a/ui-kit/android/v6/getting-started-jetpack.mdx
+++ b/ui-kit/android/v6/getting-started-jetpack.mdx
@@ -98,10 +98,10 @@ android {
 
 dependencies {
     // CometChat Jetpack Compose UI Kit
-    implementation("com.cometchat:chatuikit-compose-android:6.0.0")
+    implementation("com.cometchat:chatuikit-compose-android:6.0.3")
 
     // (Optional) Voice/video calling
-    implementation("com.cometchat:calls-sdk-android:5.0.0-beta.2")
+    implementation("com.cometchat:calls-sdk-android:5.0.1")
 }
 ```
 

--- a/ui-kit/android/v6/getting-started-kotlin.mdx
+++ b/ui-kit/android/v6/getting-started-kotlin.mdx
@@ -93,10 +93,10 @@ android {
 
 dependencies {
     // CometChat Kotlin UI Kit
-    implementation("com.cometchat:chatuikit-kotlin-android:6.0.0")
+    implementation("com.cometchat:chatuikit-kotlin-android:6.0.3")
 
     // (Optional) Voice/video calling
-    implementation("com.cometchat:calls-sdk-android:5.0.0-beta.2")
+    implementation("com.cometchat:calls-sdk-android:5.0.1")
 }
 ```
 

--- a/ui-kit/android/v6/getting-started.mdx
+++ b/ui-kit/android/v6/getting-started.mdx
@@ -88,8 +88,8 @@ Inside `libs.versions.toml`, add the versions:
 
 ```toml libs.versions.toml
 [versions]
-cometchat-ui-kit = "6.0.0"
-cometchat-calls-sdk = "5.0.0-beta.2"
+cometchat-ui-kit = "6.0.3"
+cometchat-calls-sdk = "5.0.1"
 ```
 
 Define the libraries — pick the module for your UI toolkit:
@@ -132,10 +132,10 @@ Open the app-level `build.gradle.kts` file and add the dependency for your chose
 <Tab title="Kotlin (XML Views)">
 ```kotlin build.gradle.kts
 dependencies {
-    implementation("com.cometchat:chatuikit-kotlin-android:6.0.0")
+    implementation("com.cometchat:chatuikit-kotlin-android:6.0.3")
 
     // (Optional) Include if using voice/video calling features
-    implementation("com.cometchat:calls-sdk-android:5.0.0-beta.2")
+    implementation("com.cometchat:calls-sdk-android:5.0.1")
 }
 ```
 </Tab>
@@ -143,10 +143,10 @@ dependencies {
 <Tab title="Jetpack Compose">
 ```kotlin build.gradle.kts
 dependencies {
-    implementation("com.cometchat:chatuikit-compose-android:6.0.0")
+    implementation("com.cometchat:chatuikit-compose-android:6.0.3")
 
     // (Optional) Include if using voice/video calling features
-    implementation("com.cometchat:calls-sdk-android:5.0.0-beta.2")
+    implementation("com.cometchat:calls-sdk-android:5.0.1")
 }
 ```
 </Tab>

--- a/ui-kit/android/v6/guide-ai-agent.mdx
+++ b/ui-kit/android/v6/guide-ai-agent.mdx
@@ -26,7 +26,7 @@ Enable intelligent conversational AI capabilities in your Android app using Come
 Transform your chat experience with AI-powered assistance that provides intelligent responses and seamless integration with your existing chat infrastructure.
 
 <Note>
-**1:1 conversations only.** AI Agents currently respond only in one-on-one conversations between an end user and the agent user. They do not respond to messages sent in groups, even if the agent user is added as a member or owner. Group support is on the roadmap — share your use case on [feedback.cometchat.com](https://feedback.cometchat.com).
+**1:1 and group conversations.** AI Agents work in both one-on-one and group conversations. In a 1:1 chat, the end user talks directly with the agent user. In a group, the agent participates as a member — its messages (including cards) are rendered and attributed like any other member's message.
 </Note>
 
 ## Overview


### PR DESCRIPTION
## Description

Updates the v6 Android UI Kit AI Agent guide to reflect group-conversation support shipped in UIKit Android v6.0.3 (cometchat-team/uikit-android#838).

Previously the guide stated AI Agents work in **1:1 conversations only** and that group support was "on the roadmap." As of v6.0.3, the UI Kit renders and attributes agent-generated messages (including cards) in group conversations, so the note is now inaccurate.

The note now reads:

> **1:1 and group conversations.** AI Agents work in both one-on-one and group conversations. In a 1:1 chat, the end user talks directly with the agent user. In a group, the agent participates as a member — its messages (including cards) are rendered and attributed like any other member's message.

## Related Issue(s)

<!-- n/a -->

## Type of Change

- [x] Documentation correction/update
- [ ] New documentation
- [x] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request