### PR TITLE
docs(ui-kit/angular): document Card Message rendering

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2607,7 +2607,8 @@
                                   "ui-kit/angular/ai-features"
                                 ]
                               },
-                              "ui-kit/angular/call-features"
+                              "ui-kit/angular/call-features",
+                              "ui-kit/angular/campaigns"
                             ]
                           },
                           {
@@ -2739,7 +2740,8 @@
                                   "ui-kit/angular/components/cometchat-ai-assistant-chat",
                                   "ui-kit/angular/components/cometchat-markdown-renderer"
                                 ]
-                              }
+                              },
+                              "ui-kit/angular/components/notification-feed"
                             ]
                           },
                           {

--- a/docs.json
+++ b/docs.json
@@ -2698,6 +2698,7 @@
                                 "group": "Message Bubbles",
                                 "pages": [
                                   "ui-kit/angular/components/cometchat-text-bubble",
+                                  "ui-kit/angular/components/cometchat-card-bubble",
                                   "ui-kit/angular/components/cometchat-image-bubble",
                                   "ui-kit/angular/components/cometchat-video-bubble",
                                   "ui-kit/angular/components/cometchat-audio-bubble",
@@ -2764,6 +2765,7 @@
                               "ui-kit/angular/guides/search-messages",
                               "ui-kit/angular/guides/rich-text-formatting",
                               "ui-kit/angular/guides/custom-message-types",
+                              "ui-kit/angular/guides/card-messages",
                               "ui-kit/angular/guides/custom-text-formatter",
                               "ui-kit/angular/guides/mentions-formatter",
                               "ui-kit/angular/guides/shortcut-formatter",

--- a/ui-kit/angular/campaigns.mdx
+++ b/ui-kit/angular/campaigns.mdx
@@ -1,0 +1,223 @@
+---
+title: "Campaigns"
+description: "Deliver targeted, rich notifications to users via an in-app notification feed powered by the CometChat Cards renderer."
+---
+
+CometChat Campaigns enables you to send rich, interactive notifications to users through an in-app notification feed. Each notification is rendered as a native card using the **CometChat Cards** library — supporting images, text, buttons, layouts, and interactive actions.
+
+<Note>
+Before proceeding, ensure you have completed the [UI Kit integration](/ui-kit/angular/integration) and the [Dashboard Setup](/campaigns#setup-flow) for Campaigns.
+</Note>
+
+<Frame>
+  <img src="/images/campaigns-overview-web.png" />
+</Frame>
+
+---
+
+## Overview
+
+Campaigns delivers notifications as **Card Schema JSON** — a structured format that defines the visual layout of each notification card. The system consists of three layers:
+
+1. **CometChat Chat SDK** — Fetches feed items, manages read/delivered state, provides real-time listeners, handles push notification tracking
+2. **CometChat Cards Library** (`@cometchat/cards-angular`) — Renders Card Schema JSON into native DOM elements
+3. **CometChat UI Kit** — Provides the ready-to-use `CometChatNotificationFeedComponent` component that wires everything together
+
+### Architecture Flow
+
+```
+Dashboard / API → Campaign Created → Push + WebSocket Delivery
+                                  ↓
+                SDK: NotificationFeedRequestBuilder.fetchNext()
+                                  ↓
+                NotificationFeedItem.getContent() → Card Schema JSON
+                                  ↓
+                Cards Library: CometChatCardView
+                                  ↓
+                Native Rendered Card (images, text, buttons, layouts)
+                                  ↓
+                User clicks button → actionClick output → Your code handles it
+```
+
+---
+
+## How Cards Work
+
+Each `NotificationFeedItem` from the SDK contains a `content` field — an object holding the Card Schema JSON. This JSON is passed directly to the CometChat Cards renderer which produces a DOM element.
+
+The Cards library is a **pure renderer**:
+- **Input**: Card Schema JSON string + theme mode + optional action callback
+- **Output**: Native DOM element hierarchy
+
+It does not execute actions, manage message state, or call any SDK methods. When users click interactive elements (buttons, links), the library emits the action to your callback. You decide what happens — open a URL, navigate to a chat, make an API call, etc.
+
+### Card Schema JSON Example
+
+```json
+{
+  "version": "1.0",
+  "body": [
+    {
+      "type": "column",
+      "backgroundColor": {
+        "light": "transparent",
+        "dark": "transparent"
+      },
+      "gap": 5,
+      "items": [
+        {
+          "type": "text",
+          "content": "📢 Announcement",
+          "variant": "heading2",
+          "id": "txt_99323141-2459-4e33-88d3-ca39c5fd2f50"
+        },
+        {
+          "type": "text",
+          "content": "Your announcement message here.",
+          "variant": "body",
+          "id": "txt_61a417bc-5e4a-4ba2-bfe7-b7bc64dbaf35"
+        },
+        {
+          "type": "divider",
+          "id": "div_80f5c7fb-fd10-41d1-8c2f-51498f0f62d0"
+        },
+        {
+          "type": "button",
+          "label": "Learn More",
+          "backgroundColor": {
+            "light": "transparent",
+            "dark": "transparent"
+          },
+          "textColor": {
+            "light": "#6C5CE7",
+            "dark": "#6C5CE7"
+          },
+          "size": 40,
+          "fontSize": 13,
+          "borderRadius": 6,
+          "padding": {
+            "top": 0,
+            "right": 16,
+            "bottom": 0,
+            "left": 16
+          },
+          "action": {
+            "type": "openUrl",
+            "url": ""
+          },
+          "id": "btn_9b87a3f1-b0c6-45b9-a4c2-e22ea590f17f"
+        }
+      ],
+      "id": "col_98fed9bd-1a95-4cee-aa81-84a9016e41f2"
+    }
+  ],
+  "fallbackText": "",
+  "style": {
+    "background": {
+      "light": "#E8E8E8",
+      "dark": "#E8E8E8"
+    },
+    "borderRadius": 16,
+    "borderColor": {
+      "light": "#DFE6E9",
+      "dark": "#DFE6E9"
+    },
+    "padding": 12
+  }
+}
+```
+
+The schema supports **20 element types** (text, image, icon, avatar, badge, divider, spacer, chip, progressBar, codeBlock, markdown, row, column, grid, accordion, tabs, button, iconButton, link, table) and **9 action types** (openUrl, chatWithUser, chatWithGroup, sendMessage, copyToClipboard, downloadFile, initiateCall, apiCall, customCallback).
+
+---
+
+## How Cards Work in the UI Kit
+
+The `CometChatNotificationFeedComponent` component uses the **CometChat Cards** library internally to render each notification. Here's what happens under the hood:
+
+1. The component fetches `NotificationFeedItem` objects from the SDK
+2. For each item, it extracts the `content` field (Card Schema JSON)
+3. It passes the JSON to `CometChatCardView` from `@cometchat/cards-angular`
+4. The Cards renderer produces native UI — text, images, buttons, layouts — directly from the JSON
+5. When users click buttons/links inside a card, the action is emitted on the `actionClick` output which you handle (open URL, navigate to chat, etc.)
+
+You don't need to interact with the Cards library directly when using `CometChatNotificationFeedComponent` — it's all wired up. But if you want to render cards outside the feed (e.g., a standalone card in a modal), you can use the Cards library directly. See the [SDK Campaigns documentation](/sdk/javascript/campaigns#rendering-cards) for standalone usage.
+
+---
+
+## Handling Push Notifications for Campaigns
+
+When a campaign push notification arrives via Web Push or FCM, you should:
+
+1. **Report delivery** — Call `CometChat.markPushNotificationDelivered()` when the notification is received
+2. **Report click** — Call `CometChat.markPushNotificationClicked()` when the user clicks the notification
+3. **Deep link** — Use the announcement ID from the push payload to fetch the full item via `CometChat.getNotificationFeedItem(id)` and display it
+
+```typescript
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+
+// When push notification is received (e.g., in service worker)
+const pushNotification = new CometChat.PushNotification(pushPayloadData);
+CometChat.markPushNotificationDelivered(pushNotification);
+
+// When user clicks the notification
+CometChat.markPushNotificationClicked(pushNotification);
+
+// Navigate to feed or show specific item
+const item = await CometChat.getNotificationFeedItem(pushNotification.getId());
+```
+
+See the [SDK Campaigns documentation](/sdk/javascript/campaigns) for the complete push notification tracking API.
+
+---
+
+## Sending Campaigns
+
+Before integrating the frontend, you need to set up channels, categories, templates, and campaigns in the CometChat Dashboard. Follow the [Dashboard Setup Guide](/campaigns#setup-flow) for step-by-step instructions with screenshots.
+
+---
+
+## Using the UI Kit Component
+
+The easiest way to add a notification feed to your app is the `CometChatNotificationFeedComponent` component. It handles fetching, rendering, pagination, filtering, real-time updates, and engagement reporting out of the box.
+
+```typescript
+import { Component } from "@angular/core";
+import { CometChatNotificationFeedComponent } from "@cometchat/chat-uikit-angular";
+
+@Component({
+  selector: "app-notifications",
+  standalone: true,
+  imports: [CometChatNotificationFeedComponent],
+  template: `
+    <cometchat-notification-feed
+      (itemClick)="onItemClick($event)"
+      (backClick)="onBack()"
+    ></cometchat-notification-feed>
+  `,
+})
+export class NotificationsComponent {
+  onItemClick(item: any): void {
+    // Handle item click
+  }
+
+  onBack(): void {
+    // Navigate back
+  }
+}
+```
+
+See the full [CometChatNotificationFeed component documentation](/ui-kit/angular/components/notification-feed) for all configuration options, styling, and customization.
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="SDK Campaigns API" icon="code" href="/sdk/javascript/campaigns">
+    Full API reference for feed items, categories, engagement, and push tracking
+  </Card>
+  <Card title="CometChatNotificationFeed" icon="bell" href="/ui-kit/angular/components/notification-feed">
+    Ready-to-use component with filtering, real-time updates, and styling
+  </Card>
+</CardGroup>

--- a/ui-kit/angular/components/cometchat-card-bubble.mdx
+++ b/ui-kit/angular/components/cometchat-card-bubble.mdx
@@ -3,7 +3,7 @@ title: "Card Bubble"
 description: "Angular component that renders a developer Card Message inside a message bubble using the prebuilt CometChat Cards renderer, with pure-forwarded card actions."
 ---
 
-The `CometChatCardBubble` component renders a **developer Card Message** (`message.category === "card"`) as a card bubble inside a conversation. It is the card equivalent of [`CometChatTextBubble`](/ui-kit/angular/components/cometchat-text-bubble): the surrounding [`CometChatMessageBubble`](/ui-kit/angular/components/cometchat-message-bubble) wrapper supplies the container, receipts, reactions, long-press options, reply and thread view — this component only replaces the **content view** with the rendered card.
+The `CometChatCardBubbleComponent` renders a **developer Card Message** (`message.category === "card"`) as a card bubble inside a conversation. It is the card equivalent of [`CometChatTextBubble`](/ui-kit/angular/components/cometchat-text-bubble): the surrounding [`CometChatMessageBubble`](/ui-kit/angular/components/cometchat-message-bubble) wrapper supplies the container, receipts, reactions, long-press options, reply and thread view — this component only replaces the **content view** with the rendered card.
 
 ## Overview
 
@@ -21,7 +21,7 @@ The component follows a strict **render-only contract**:
 
 ## Automatic Rendering
 
-In the standard chat flow you do **not** instantiate this component yourself. [`CometChatMessageList`](/ui-kit/angular/components/cometchat-message-list) and `CometChatMessageBubble` route any message with category `"card"` to `CometChatCardBubble` automatically, keyed by **category** (the developer `type` is arbitrary). To handle card actions in this flow, subscribe to the [`ccCardActionClicked`](#card-actions) event bus — no component wiring is required.
+In the standard chat flow you do **not** instantiate this component yourself. [`CometChatMessageList`](/ui-kit/angular/components/cometchat-message-list) and `CometChatMessageBubble` route any message with category `"card"` to `CometChatCardBubbleComponent` automatically, keyed by **category** (the developer `type` is arbitrary). To handle card actions in this flow, subscribe to the [`ccCardActionClicked`](#card-actions) event bus — no component wiring is required.
 
 Use the component directly only when you are building a fully custom message renderer.
 
@@ -160,20 +160,21 @@ export class CardMessageComponent {
 ### Handling actions via the event bus
 
 ```typescript expandable
-import { Injectable, DestroyRef, inject } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import {
   CometChatMessageEvents,
   ICardActionEvent,
 } from '@cometchat/chat-uikit-angular';
 import type { CometChatCardAction } from '@cometchat/cards-angular';
+import { Subscription } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
-export class CardActionHandler {
-  private readonly destroyRef = inject(DestroyRef);
+export class CardActionHandler implements OnDestroy {
+  private actionSub?: Subscription;
 
   start(): void {
-    // Subscribe once; auto-unsubscribes when the injector is destroyed.
-    CometChatMessageEvents.subscribeOnCardActionClicked((event: ICardActionEvent) => {
+    // Subscribe on the event Subject; unsubscribe in ngOnDestroy.
+    this.actionSub = CometChatMessageEvents.ccCardActionClicked.subscribe((event: ICardActionEvent) => {
       const action = event.action as CometChatCardAction;
       switch (action.type) {
         case 'openUrl':
@@ -184,7 +185,11 @@ export class CardActionHandler {
           break;
         // ...handle the remaining action types
       }
-    }, this.destroyRef);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.actionSub?.unsubscribe();
   }
 }
 ```

--- a/ui-kit/angular/components/cometchat-card-bubble.mdx
+++ b/ui-kit/angular/components/cometchat-card-bubble.mdx
@@ -1,0 +1,238 @@
+---
+title: "Card Bubble"
+description: "Angular component that renders a developer Card Message inside a message bubble using the prebuilt CometChat Cards renderer, with pure-forwarded card actions."
+---
+
+The `CometChatCardBubble` component renders a **developer Card Message** (`message.category === "card"`) as a card bubble inside a conversation. It is the card equivalent of [`CometChatTextBubble`](/ui-kit/angular/components/cometchat-text-bubble): the surrounding [`CometChatMessageBubble`](/ui-kit/angular/components/cometchat-message-bubble) wrapper supplies the container, receipts, reactions, long-press options, reply and thread view — this component only replaces the **content view** with the rendered card.
+
+## Overview
+
+The UIKit is a **render-only** consumer of cards: it draws cards delivered by the SDK and forwards card actions to your app. It never parses or mutates the card body, and never sends or creates cards. When a card message arrives, the UIKit routes it to this bubble automatically.
+
+The component follows a strict **render-only contract**:
+
+- **Render-only** — the raw card payload from `message.getCard()` is serialized verbatim and handed to the prebuilt `CometChatCardView` renderer (from [`@cometchat/cards-angular`](https://www.npmjs.com/package/@cometchat/cards-angular)) as a `cardJson` string. The UI Kit performs **zero transformation** of the payload.
+- **No behavior** — the bubble runs no action logic of its own. When a user taps an interactive element, the renderer's raw action is **pure-forwarded** on two channels (see [Card Actions](#card-actions)); your app owns all behavior.
+- **Graceful fallback** — when the payload is empty or invalid, a single-line fallback text is shown instead of an empty bubble (see [Fallback Behavior](#fallback-behavior)).
+
+<Info>
+  Card rendering (layout, theming, interactive elements) is owned by the prebuilt `@cometchat/cards-angular` renderer library, **not** by the UI Kit. The UI Kit is responsible only for delivering the payload to the renderer and forwarding actions back out.
+</Info>
+
+## Automatic Rendering
+
+In the standard chat flow you do **not** instantiate this component yourself. [`CometChatMessageList`](/ui-kit/angular/components/cometchat-message-list) and `CometChatMessageBubble` route any message with category `"card"` to `CometChatCardBubble` automatically, keyed by **category** (the developer `type` is arbitrary). To handle card actions in this flow, subscribe to the [`ccCardActionClicked`](#card-actions) event bus — no component wiring is required.
+
+Use the component directly only when you are building a fully custom message renderer.
+
+## Basic Usage
+
+```typescript expandable
+import { Component } from '@angular/core';
+import { CometChat } from '@cometchat/chat-sdk-javascript';
+import {
+  CometChatCardBubbleComponent,
+  MessageBubbleAlignment,
+} from '@cometchat/chat-uikit-angular';
+
+@Component({
+  selector: 'app-card-message',
+  standalone: true,
+  imports: [CometChatCardBubbleComponent],
+  template: `
+    <cometchat-card-bubble
+      [message]="cardMessage"
+      [alignment]="MessageBubbleAlignment.left"
+    ></cometchat-card-bubble>
+  `,
+})
+export class CardMessageComponent {
+  cardMessage!: CometChat.CardMessage;
+  MessageBubbleAlignment = MessageBubbleAlignment;
+}
+```
+
+### Incoming vs Outgoing Messages
+
+```typescript expandable
+import { Component } from '@angular/core';
+import { CometChat } from '@cometchat/chat-sdk-javascript';
+import {
+  CometChatCardBubbleComponent,
+  MessageBubbleAlignment,
+} from '@cometchat/chat-uikit-angular';
+
+@Component({
+  selector: 'app-card-list',
+  standalone: true,
+  imports: [CometChatCardBubbleComponent],
+  template: `
+    <!-- Incoming card (left-aligned) -->
+    <cometchat-card-bubble
+      [message]="incomingCard"
+      [alignment]="MessageBubbleAlignment.left"
+    ></cometchat-card-bubble>
+
+    <!-- Outgoing card (right-aligned) -->
+    <cometchat-card-bubble
+      [message]="outgoingCard"
+      [alignment]="MessageBubbleAlignment.right"
+    ></cometchat-card-bubble>
+  `,
+})
+export class CardListComponent {
+  incomingCard!: CometChat.CardMessage;
+  outgoingCard!: CometChat.CardMessage;
+  MessageBubbleAlignment = MessageBubbleAlignment;
+}
+```
+
+## Properties
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `message` | `CometChat.CardMessage` | **required** | The card message to render. The raw payload is read from `message.getCard()`. |
+| `alignment` | `MessageBubbleAlignment` | `MessageBubbleAlignment.left` | Bubble alignment. `left` for incoming/receiver messages, `right` for outgoing/sender messages. Kept for parity with the text bubble. |
+| `themeMode` | `CometChatCardThemeMode` | `'auto'` | Renderer theme mode. One of `'auto'`, `'light'`, or `'dark'`. Passed straight to `CometChatCardView`. |
+| `themeOverride` | `CometChatCardThemeOverride` | `undefined` | Optional renderer theme overrides (colors, spacing, typography for the rendered card). Passed straight to `CometChatCardView`. |
+
+<Note>
+  `CometChatCardThemeMode` and `CometChatCardThemeOverride` are exported by `@cometchat/cards-angular`. Type these inputs precisely — passing `unknown` will fail strict-template AOT compilation.
+</Note>
+
+## Events
+
+| Event | Payload Type | Description |
+|-------|-------------|-------------|
+| `onCardAction` | `CardBubbleAction` | Emitted when a user taps an interactive element on the card. Carries the raw renderer action. |
+
+```typescript
+/** Payload emitted by the bubble's onCardAction output. */
+export interface CardBubbleAction {
+  message: CometChat.CardMessage; // the card message the action originated from
+  action: unknown;                // the renderer's raw discriminated action
+}
+```
+
+## Card Actions
+
+The Cards renderer is a **pure renderer** — it emits actions through callbacks without executing them. The bubble forwards each action on **both** channels and runs no behavior of its own:
+
+1. **`(onCardAction)` output** — for apps that render this bubble directly.
+2. **`CometChatMessageEvents.ccCardActionClicked` event bus** — for the standard, internally rendered flow where the bubble is created by the UI Kit. This is the recommended channel for the default message list.
+
+<Warning>
+  Act on **one** channel only to avoid double-handling the same tap. In the standard `CometChatMessageList` flow, use the `ccCardActionClicked` bus.
+</Warning>
+
+### Handling actions via the output
+
+```typescript expandable
+import { Component } from '@angular/core';
+import { CometChat } from '@cometchat/chat-sdk-javascript';
+import {
+  CometChatCardBubbleComponent,
+  CardBubbleAction,
+} from '@cometchat/chat-uikit-angular';
+
+@Component({
+  selector: 'app-card-message',
+  standalone: true,
+  imports: [CometChatCardBubbleComponent],
+  template: `
+    <cometchat-card-bubble
+      [message]="cardMessage"
+      (onCardAction)="onCardAction($event)"
+    ></cometchat-card-bubble>
+  `,
+})
+export class CardMessageComponent {
+  cardMessage!: CometChat.CardMessage;
+
+  onCardAction(event: CardBubbleAction): void {
+    // event.action is the raw renderer action (a CometChatCardAction).
+    // Your app implements the behavior — the UI Kit performs none.
+    console.log('Card action on message', event.message.getId(), event.action);
+  }
+}
+```
+
+### Handling actions via the event bus
+
+```typescript expandable
+import { Injectable, DestroyRef, inject } from '@angular/core';
+import {
+  CometChatMessageEvents,
+  ICardActionEvent,
+} from '@cometchat/chat-uikit-angular';
+import type { CometChatCardAction } from '@cometchat/cards-angular';
+
+@Injectable({ providedIn: 'root' })
+export class CardActionHandler {
+  private readonly destroyRef = inject(DestroyRef);
+
+  start(): void {
+    // Subscribe once; auto-unsubscribes when the injector is destroyed.
+    CometChatMessageEvents.subscribeOnCardActionClicked((event: ICardActionEvent) => {
+      const action = event.action as CometChatCardAction;
+      switch (action.type) {
+        case 'openUrl':
+          window.open(action.url, '_blank', 'noopener,noreferrer');
+          break;
+        case 'copyToClipboard':
+          navigator.clipboard?.writeText(action.value);
+          break;
+        // ...handle the remaining action types
+      }
+    }, this.destroyRef);
+  }
+}
+```
+
+The full set of action types and a complete reference handler are covered in the [Card Messages guide](/ui-kit/angular/guides/card-messages#handling-card-actions).
+
+## Fallback Behavior
+
+When `getCard()` returns nothing drawable (`null`, a blank string, or an empty object), the bubble renders a single line of fallback text instead of an empty card. The fallback is resolved in this order:
+
+1. `message.getFallbackText()`
+2. `message.getText()`
+3. Localized `"Card Message"` (the `card_message` localization key)
+
+This keeps the conversation readable even if a card payload is malformed or a client cannot render it.
+
+## Customization
+
+The card's internal layout, colors, and typography are controlled by the renderer through [`themeMode`](#properties) and [`themeOverride`](#properties). The bubble wrapper and fallback line are styled with CSS variables:
+
+```css expandable
+cometchat-card-bubble {
+  /* Spacing around the card content */
+  --cometchat-spacing-2: 8px;
+  --cometchat-spacing-3: 12px;
+
+  /* Fallback text */
+  --cometchat-font-body-regular: 400 14px 'Inter';
+  --cometchat-text-color-secondary: #666666;
+
+  /* Bubble surface (incoming) */
+  --cometchat-background-color-02: #F5F5F5;
+  --cometchat-radius-3: 12px;
+}
+```
+
+To restyle the rendered card itself (button colors, header, body), pass a `themeOverride` to the bubble rather than overriding CSS — the card DOM is owned by the renderer.
+
+## Technical Details
+
+- **Standalone Component** — import and use independently.
+- **Change Detection** — `OnPush` for optimal performance; uses Angular signals for the card payload and fallback.
+- **Renderer dependency** — `CometChatCardViewComponent` from `@cometchat/cards-angular`.
+- **Callback before schema** — the renderer's `(onAction)` output is bound before `[cardJson]` is assigned, so the action callback is registered before the card schema is rendered.
+
+## Related
+
+- **[Card Messages guide](/ui-kit/angular/guides/card-messages)** — the full card rendering implementation: developer cards, agent cards, streaming cards, and the complete action vocabulary.
+- **[CometChatMessageBubble](/ui-kit/angular/components/cometchat-message-bubble)** — routes card messages to this bubble.
+- **[CometChatMessageList](/ui-kit/angular/components/cometchat-message-list)** — renders card bubbles in the conversation.
+- **[Events](/ui-kit/angular/events)** — the `ccCardActionClicked` event reference.

--- a/ui-kit/angular/components/notification-feed.mdx
+++ b/ui-kit/angular/components/notification-feed.mdx
@@ -1,0 +1,453 @@
+---
+title: "Notification Feed"
+description: "Full-screen notification feed component with category filtering, card rendering, real-time updates, and engagement reporting."
+---
+
+<Accordion title="AI Integration Quick Reference">
+```json
+{
+  "component": "CometChatNotificationFeedComponent",
+  "package": "@cometchat/chat-uikit-angular",
+  "selector": "cometchat-notification-feed",
+  "import": "import { CometChatNotificationFeedComponent } from \"@cometchat/chat-uikit-angular\";",
+  "description": "Full-screen notification feed with category filtering, timestamp grouping, card rendering via @cometchat/cards-angular, real-time updates, and automatic engagement reporting.",
+  "cssRootClass": ".cometchat-notification-feed",
+  "inputs": {
+    "data": {
+      "notificationFeedRequestBuilder": { "type": "CometChat.NotificationFeedRequestBuilder", "default": "SDK default (15 per page)" },
+      "notificationCategoriesRequestBuilder": { "type": "CometChat.NotificationCategoriesRequestBuilder", "default": "SDK default" },
+      "scrollToItemId": { "type": "string", "default": "undefined" }
+    },
+    "visibility": {
+      "title": { "type": "string", "default": "localized \"Notifications\"" },
+      "showHeader": { "type": "boolean", "default": true },
+      "showBackButton": { "type": "boolean", "default": false },
+      "showFilterChips": { "type": "boolean", "default": true }
+    },
+    "templates": {
+      "headerView": "TemplateRef<any>",
+      "emptyStateView": "TemplateRef<any>",
+      "errorStateView": "TemplateRef<any>",
+      "loadingStateView": "TemplateRef<any>"
+    },
+    "cards": {
+      "cardThemeMode": { "type": "\"auto\" | \"light\" | \"dark\"", "default": "\"auto\"" },
+      "cardThemeOverride": { "type": "Record<string, any>", "default": "undefined" }
+    },
+    "style": { "type": "CometChatNotificationFeedStyle", "default": "undefined" }
+  },
+  "outputs": {
+    "itemClick": "EventEmitter<NotificationFeedItem>",
+    "actionClick": "EventEmitter<{ item: NotificationFeedItem; action: CardAction }>",
+    "error": "EventEmitter<CometChat.CometChatException>",
+    "backClick": "EventEmitter<void>"
+  },
+  "automaticBehaviors": [
+    "Real-time updates via addNotificationFeedListener",
+    "Delivery reporting on fetch",
+    "Read reporting on viewport visibility (IntersectionObserver)",
+    "Unread count polling every 30 seconds",
+    "Infinite scroll pagination",
+    "Timestamp grouping (Today, Yesterday, day name, date)",
+    "Category filter chips with unread badges"
+  ]
+}
+```
+</Accordion>
+
+`CometChatNotificationFeedComponent` displays a scrollable notification feed where each item is rendered as a card using `@cometchat/cards-angular`. It handles fetching, pagination, category filtering, timestamp grouping, real-time updates, and read/delivered/engagement reporting automatically.
+
+<Frame>
+  <img src="/images/campaigns-overview-web.png" />
+</Frame>
+
+---
+
+## Where It Fits
+
+`CometChatNotificationFeedComponent` is a full-screen, standalone component. Drop it into a page or route. It manages its own data fetching, state, and real-time listeners — you just handle the navigation outputs.
+
+```typescript
+import { Component } from "@angular/core";
+import { CometChatNotificationFeedComponent } from "@cometchat/chat-uikit-angular";
+
+@Component({
+  selector: "app-notifications-page",
+  standalone: true,
+  imports: [CometChatNotificationFeedComponent],
+  template: `
+    <cometchat-notification-feed
+      [showBackButton]="true"
+      (backClick)="goBack()"
+      (itemClick)="onItemClick($event)"
+    ></cometchat-notification-feed>
+  `,
+})
+export class NotificationsPageComponent {
+  goBack(): void {
+    history.back();
+  }
+
+  onItemClick(item: any): void {
+    // Handle item click (e.g., open detail or deep link)
+  }
+}
+```
+
+---
+
+## Minimal Render
+
+```typescript
+import { Component } from "@angular/core";
+import { CometChatNotificationFeedComponent } from "@cometchat/chat-uikit-angular";
+
+@Component({
+  selector: "app-notifications-demo",
+  standalone: true,
+  imports: [CometChatNotificationFeedComponent],
+  template: `
+    <div style="width: 100%; height: 100vh;">
+      <cometchat-notification-feed></cometchat-notification-feed>
+    </div>
+  `,
+})
+export class NotificationsDemoComponent {}
+```
+
+Prerequisites: CometChat SDK initialized with `CometChatUIKit.init()` and a user logged in.
+
+Root CSS class: `.cometchat-notification-feed`
+
+---
+
+## Filtering Feed Items
+
+Control what loads using a custom request builder:
+
+```typescript
+import { Component } from "@angular/core";
+import { CometChat } from "@cometchat/chat-sdk-javascript";
+import { CometChatNotificationFeedComponent } from "@cometchat/chat-uikit-angular";
+
+@Component({
+  selector: "app-unread-notifications",
+  standalone: true,
+  imports: [CometChatNotificationFeedComponent],
+  template: `
+    <cometchat-notification-feed
+      [notificationFeedRequestBuilder]="requestBuilder"
+    ></cometchat-notification-feed>
+  `,
+})
+export class UnreadNotificationsComponent {
+  requestBuilder = new CometChat.NotificationFeedRequestBuilder()
+    .setLimit(30)
+    .setReadState("unread")
+    .setCategory("promotions")
+    .build();
+}
+```
+
+### Filter Options
+
+| Builder Method | Description |
+| --- | --- |
+| `.setLimit(number)` | Items per page (default 15) |
+| `.setReadState(state)` | `"read"`, `"unread"`, or `"all"` |
+| `.setCategory(string)` | Filter by category |
+| `.setChannelId(string)` | Filter by channel |
+| `.setTags(string[])` | Filter by tags |
+| `.setDateFrom(string)` | ISO 8601 date lower bound |
+| `.setDateTo(string)` | ISO 8601 date upper bound |
+
+---
+
+## Actions and Events
+
+### Outputs
+
+#### itemClick
+
+Fires when a feed item card is clicked. Emits the `NotificationFeedItem`.
+
+```html
+<cometchat-notification-feed
+  (itemClick)="onItemClick($event)"
+></cometchat-notification-feed>
+```
+
+```typescript
+onItemClick(item: any): void {
+  console.log("Item clicked:", item.getId());
+}
+```
+
+#### actionClick
+
+Fires when an interactive element (button, link) inside a card is clicked. Emits `{ item, action }`, where `action` contains the action type, parameters, and the element ID that triggered it.
+
+```html
+<cometchat-notification-feed
+  (actionClick)="onActionClick($event)"
+></cometchat-notification-feed>
+```
+
+```typescript
+onActionClick(event: { item: any; action: any }): void {
+  const { type, params, elementId } = event.action;
+  switch (type) {
+    case "openUrl":
+      window.open(params.url, "_blank");
+      break;
+    case "chatWithUser":
+      // Navigate to chat with params.uid
+      break;
+    case "chatWithGroup":
+      // Navigate to group chat with params.guid
+      break;
+  }
+}
+```
+
+#### error
+
+Fires when an internal error occurs (network failure, SDK exception). Emits a `CometChat.CometChatException`.
+
+```html
+<cometchat-notification-feed
+  (error)="onError($event)"
+></cometchat-notification-feed>
+```
+
+#### backClick
+
+Fires when the back button in the header is clicked. Emits `void`.
+
+```html
+<cometchat-notification-feed
+  [showBackButton]="true"
+  (backClick)="goBack()"
+></cometchat-notification-feed>
+```
+
+### Automatic Behaviors
+
+The component handles these automatically — no manual setup needed:
+
+| Behavior | Description |
+| --- | --- |
+| Real-time updates | New items appear at the top via `addNotificationFeedListener` |
+| Delivery reporting | Items are reported as delivered when fetched (`markFeedItemAsDelivered`) |
+| Read reporting | Items are reported as read when visible in the viewport (IntersectionObserver → `markFeedItemAsRead`) |
+| Unread count polling | Polls the unread count every 30 seconds to update badges |
+| Infinite scroll | Fetches the next page when scrolling near the bottom |
+| Timestamp grouping | Groups items as "Today", "Yesterday", day name, or date |
+| Category filtering | Filter chips row with per-category unread badges |
+
+---
+
+## Customization
+
+### Template Slots
+
+Replace individual regions with your own `ng-template`. Bind the template reference to the matching input:
+
+```html
+<cometchat-notification-feed
+  [headerView]="header"
+  [emptyStateView]="empty"
+  [loadingStateView]="loading"
+  [errorStateView]="errorTpl"
+></cometchat-notification-feed>
+
+<ng-template #header>
+  <!-- custom header -->
+</ng-template>
+<ng-template #empty>
+  <!-- custom empty state -->
+</ng-template>
+<ng-template #loading>
+  <!-- custom loading state -->
+</ng-template>
+<ng-template #errorTpl>
+  <!-- custom error state -->
+</ng-template>
+```
+
+| Input | Type | Replaces |
+| --- | --- | --- |
+| `headerView` | `TemplateRef<any>` | Entire header bar |
+| `loadingStateView` | `TemplateRef<any>` | Loading state |
+| `emptyStateView` | `TemplateRef<any>` | Empty state |
+| `errorStateView` | `TemplateRef<any>` | Error state |
+
+### Style Input
+
+Pass a `CometChatNotificationFeedStyle` object to override colors, fonts, and dimensions without writing CSS:
+
+```typescript
+import { CometChatNotificationFeedStyle } from "@cometchat/chat-uikit-angular";
+
+feedStyle: CometChatNotificationFeedStyle = {
+  backgroundColor: "#1a1a2e",
+  headerTitleColor: "#ffffff",
+  chipActiveBackgroundColor: "#6852d6",
+  cardBorderRadius: "12px",
+};
+```
+
+```html
+<cometchat-notification-feed [style]="feedStyle"></cometchat-notification-feed>
+```
+
+| Field | Type |
+| --- | --- |
+| `backgroundColor` | `string` |
+| `width` / `height` | `string` |
+| `headerTitleColor` / `headerTitleFont` | `string` |
+| `chipActiveBackgroundColor` / `chipActiveTextColor` | `string` |
+| `chipInactiveBackgroundColor` / `chipInactiveTextColor` | `string` |
+| `chipBorderColor` | `string` |
+| `badgeBackgroundColor` / `badgeTextColor` | `string` |
+| `separatorColor` | `string` |
+| `timestampTextColor` / `timestampFont` | `string` |
+| `cardBackgroundColor` / `cardBorderColor` / `cardBorderRadius` / `cardBorderWidth` | `string` |
+| `unreadIndicatorColor` | `string` |
+
+### CSS Styling
+
+Override design tokens on the component selector:
+
+```css
+cometchat-notification-feed {
+  --cometchat-background-color-01: #1a1a2e;
+  --cometchat-text-color-primary: #ffffff;
+}
+```
+
+### CSS Classes
+
+| Class | Description |
+| --- | --- |
+| `.cometchat-notification-feed` | Root container |
+| `.cometchat-notification-feed__header` | Header bar |
+| `.cometchat-notification-feed__header-title` | Header title text |
+| `.cometchat-notification-feed__header-back` | Back button |
+| `.cometchat-notification-feed__chips` | Filter chips container |
+| `.cometchat-notification-feed__chip` | Individual filter chip |
+| `.cometchat-notification-feed__chip--active` | Active filter chip |
+| `.cometchat-notification-feed__chip--inactive` | Inactive filter chip |
+| `.cometchat-notification-feed__chip-badge` | Chip unread badge |
+| `.cometchat-notification-feed__content` | Scrollable content area |
+| `.cometchat-notification-feed__item` | Feed item container |
+| `.cometchat-notification-feed__item--unread` | Unread feed item |
+| `.cometchat-notification-feed__unread-indicator` | Unread dot indicator |
+| `.cometchat-notification-feed__item-meta` | Item metadata row (category + time) |
+| `.cometchat-notification-feed__card-container` | Card wrapper |
+| `.cometchat-notification-feed__loading` | Loading state |
+| `.cometchat-notification-feed__empty` | Empty state |
+| `.cometchat-notification-feed__error` | Error state |
+
+---
+
+## Inputs
+
+All inputs are optional.
+
+| Input | Type | Default | Description |
+| --- | --- | --- | --- |
+| `title` | `string` | localized `"Notifications"` | Header title text |
+| `showHeader` | `boolean` | `true` | Shows/hides the entire header |
+| `showBackButton` | `boolean` | `false` | Shows/hides the back button in the header |
+| `showFilterChips` | `boolean` | `true` | Shows/hides the category filter chips row |
+| `scrollToItemId` | `string` | `undefined` | Deep link: scroll to a specific item by ID on load |
+| `notificationFeedRequestBuilder` | `CometChat.NotificationFeedRequestBuilder` | SDK default | Custom request builder for fetching feed items |
+| `notificationCategoriesRequestBuilder` | `CometChat.NotificationCategoriesRequestBuilder` | SDK default | Custom request builder for fetching categories |
+| `headerView` | `TemplateRef<any>` | Built-in header | Custom header template |
+| `emptyStateView` | `TemplateRef<any>` | Built-in empty state | Custom empty state template |
+| `errorStateView` | `TemplateRef<any>` | Built-in error state | Custom error state template |
+| `loadingStateView` | `TemplateRef<any>` | Built-in loading state | Custom loading state template |
+| `style` | `CometChatNotificationFeedStyle` | `undefined` | Structured style overrides |
+| `cardThemeMode` | `"auto" \| "light" \| "dark"` | `"auto"` | Theme mode forwarded to `@cometchat/cards-angular` |
+| `cardThemeOverride` | `Record<string, any>` | `undefined` | Theme override forwarded to `@cometchat/cards-angular` |
+
+## Outputs
+
+| Output | Payload | Description |
+| --- | --- | --- |
+| `itemClick` | `NotificationFeedItem` | A feed item card was clicked |
+| `actionClick` | `{ item: NotificationFeedItem; action: CardAction }` | An interactive element inside a card was clicked |
+| `error` | `CometChat.CometChatException` | The component encountered an error |
+| `backClick` | `void` | The back button was pressed |
+
+The `CardAction` object contains:
+- `type` — Action type (e.g., `"openUrl"`, `"chatWithUser"`)
+- `params` — Action parameters (e.g., `{ url: "..." }`, `{ uid: "..." }`)
+- `elementId` — ID of the element that triggered the action
+- `cardJson` — The raw card JSON the action originated from
+
+---
+
+## Common Patterns
+
+### Show only unread items
+
+```typescript
+requestBuilder = new CometChat.NotificationFeedRequestBuilder()
+  .setReadState("unread")
+  .build();
+```
+
+```html
+<cometchat-notification-feed
+  [notificationFeedRequestBuilder]="requestBuilder"
+></cometchat-notification-feed>
+```
+
+### Hide filter chips and header
+
+```html
+<cometchat-notification-feed
+  [showHeader]="false"
+  [showFilterChips]="false"
+></cometchat-notification-feed>
+```
+
+### Embed in a sidebar
+
+```html
+<div style="width: 400px; height: 100vh; border-left: 1px solid #E0E0E0;">
+  <cometchat-notification-feed
+    title="Updates"
+    [showBackButton]="false"
+  ></cometchat-notification-feed>
+</div>
+```
+
+### Deep link to a specific notification
+
+```html
+<cometchat-notification-feed
+  [scrollToItemId]="announcementId"
+></cometchat-notification-feed>
+```
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Campaigns Feature" icon="bullhorn" href="/ui-kit/angular/campaigns">
+    Overview of how campaigns work end-to-end
+  </Card>
+  <Card title="SDK Campaigns API" icon="code" href="/sdk/javascript/campaigns">
+    Low-level SDK APIs for feed items, categories, and engagement
+  </Card>
+  <Card title="Theming" icon="paintbrush" href="/ui-kit/angular/customization/theming">
+    Customize colors, fonts, and appearance
+  </Card>
+  <Card title="Components" icon="grid-2" href="/ui-kit/angular/components/components-overview">
+    Browse all prebuilt UI components
+  </Card>
+</CardGroup>

--- a/ui-kit/angular/events.mdx
+++ b/ui-kit/angular/events.mdx
@@ -54,6 +54,7 @@ Events provide decoupled communication between UIKit components using a publish/
 | **ccMessageDeleted**  | Triggered when the user successfully deletes a message.                                                   |
 | **ccMessageRead**     | Triggered when the sent message is read by the receiver.                                                  |
 | **ccLiveReaction**    | Triggered when the user sends a live reaction.                                                            |
+| **ccCardActionClicked** | Triggered when a user taps an interactive element on a card (developer card or nested agent card). Carries an `ICardActionEvent` with the owning `message` (or `null` for a streaming card), the raw renderer `action`, and the originating `elementId`/`cardJson`. The UIKit forwards the action untouched and runs no behavior. See the [Card Messages guide](/ui-kit/angular/guides/card-messages#handling-card-actions). |
 
 ### SDK Listener Events
 
@@ -69,6 +70,7 @@ Events provide decoupled communication between UIKit components using a publish/
 | **onMessageEdited**              | Emitted when the CometChat SDK listener indicates that a message has been edited.        |
 | **onMessageDeleted**             | Emitted when the CometChat SDK listener indicates that a message has been deleted.       |
 | **onTransientMessageReceived**   | Emitted when the CometChat SDK listener receives a transient message.                    |
+| **onCardMessageReceived**        | Emitted when the CometChat SDK listener receives a developer card message (`category: "card"`). Carries a `CometChat.CardMessage`. The UIKit renders cards but never sends or creates them. |
 
 ## CometChatCallEvents
 

--- a/ui-kit/angular/guides/card-messages.mdx
+++ b/ui-kit/angular/guides/card-messages.mdx
@@ -1,0 +1,241 @@
+---
+title: "Card Messages"
+description: "How the Angular UIKit renders Card Messages — developer cards, persisted agent cards, and streaming agent cards — and how to handle card actions."
+---
+
+<Accordion title="AI Integration Quick Reference">
+
+| Field | Value |
+| --- | --- |
+| Package | `@cometchat/chat-uikit-angular` |
+| Renderer | `@cometchat/cards-angular` (`CometChatCardView`) |
+| Components | `CometChatCardBubble`, `CometChatAIAssistantMessageBubble`, `CometChatStreamMessageBubble` |
+| Key event | `CometChatMessageEvents.ccCardActionClicked` |
+| Required setup | `CometChatUIKit.init(uiKitSettings)` then `CometChatUIKit.login("UID")` |
+| Purpose | Render structured, interactive card payloads inside conversations and forward card actions to your app |
+| Related | [Card Bubble](/ui-kit/angular/components/cometchat-card-bubble) \| [AI Assistant Chat](/ui-kit/angular/components/cometchat-ai-assistant-chat) \| [Events](/ui-kit/angular/events) |
+
+</Accordion>
+
+Card Messages are structured, interactive cards delivered inside conversations. The Angular UIKit renders them through the prebuilt [`@cometchat/cards-angular`](https://www.npmjs.com/package/@cometchat/cards-angular) renderer and forwards every card action back to your application.
+
+<Info>
+  The UIKit is a **render-only** consumer of cards: it draws cards delivered by the SDK and forwards their actions to your app. It never parses or mutates the card body, and never sends or creates cards.
+</Info>
+
+## The render-only contract
+
+The UIKit is a **render-only** consumer of cards. For every card surface, the rules are identical:
+
+1. **Pass the payload through unchanged.** The raw card payload is read from the SDK, serialized verbatim (`JSON.stringify`), and handed to `CometChatCardView` as a `cardJson` string. The UIKit performs **no transformation**.
+2. **Forward actions, run no behavior.** The renderer emits actions through callbacks. The UIKit forwards them on the `ccCardActionClicked` event bus. Your app implements **all** behavior (open a URL, start a chat, call an API, …).
+3. **Fall back gracefully.** When a payload is empty or invalid, a single fallback line is shown instead of a broken card.
+
+This contract is centralized in a small set of helpers so the developer bubble, the agent bubble, and the streaming bubble all treat payloads identically.
+
+## Three delivery paths
+
+A card can reach the conversation in three ways. The UIKit routes each one to the correct renderer automatically.
+
+| Path | Source | Component | Routed by |
+| --- | --- | --- | --- |
+| **Developer card** | `CardMessage` with `category: "card"` | [`CometChatCardBubble`](/ui-kit/angular/components/cometchat-card-bubble) | message **category** |
+| **Persisted agent card** | `AIAssistantMessage` content block | `CometChatAIAssistantMessageBubble` | element `type: "card"` |
+| **Streaming agent card** | Live `card_start` / `card` / `card_end` events | `CometChatStreamMessageBubble` | stream event type |
+
+### Developer cards
+
+A message with category `"card"` is routed to `CometChatCardBubble` by [`CometChatMessageBubble`](/ui-kit/angular/components/cometchat-message-bubble), keyed on **category** (the developer `type` is arbitrary). The bubble renders `message.getCard()` and forwards taps on the `ccCardActionClicked` bus.
+
+In the conversation list, a card message's preview is its `getText()` if present, otherwise the localized `"Card Message"` label.
+
+To react to incoming developer cards in real time, listen on the message bus:
+
+```typescript expandable
+import { Injectable, DestroyRef, inject } from '@angular/core';
+import { CometChat } from '@cometchat/chat-sdk-javascript';
+import { CometChatMessageEvents } from '@cometchat/chat-uikit-angular';
+
+@Injectable({ providedIn: 'root' })
+export class CardListener {
+  private readonly destroyRef = inject(DestroyRef);
+
+  start(): void {
+    CometChatMessageEvents.subscribeOnCardMessageReceived(
+      (card: CometChat.CardMessage) => {
+        console.log('Card received:', card.getId(), card.getCard());
+      },
+      this.destroyRef
+    );
+  }
+}
+```
+
+See the [Card Bubble](/ui-kit/angular/components/cometchat-card-bubble) component reference for inputs, events, and theming.
+
+### Persisted agent cards
+
+After an AI agent run completes, the persisted `AIAssistantMessage` exposes its content as an **ordered list of blocks** via `getElements()`. `CometChatAIAssistantMessageBubble` renders them in order:
+
+- a `text` block renders as Markdown (via [`CometChatMarkdownRenderer`](/ui-kit/angular/components/cometchat-markdown-renderer));
+- a `card` block renders through `CometChatCardView`, using the same render-only path as developer cards.
+
+When a message has no elements (older messages), the bubble falls back to `getText()`. No additional wiring is required — the [AI Assistant Chat](/ui-kit/angular/components/cometchat-ai-assistant-chat) flow instantiates this bubble for you. Taps on a nested agent card are forwarded on the same `ccCardActionClicked` bus.
+
+### Streaming agent cards
+
+While an agent run is streaming, cards arrive progressively and are rendered by `CometChatStreamMessageBubble`, which subscribes to the streaming service's `messageStream$`:
+
+| Stream event | Behavior |
+| --- | --- |
+| `card_start` | Shows an in-place loader labeled with the event's `executionText`, keyed by `cardId`. |
+| `card` | Replaces the loader (correlated by `cardId`) with the rendered card. |
+| `card_end` | No-op — the run-complete persisted `AIAssistantMessage` replaces the streamed bubble. |
+
+Because no persisted message exists yet during streaming, a tap on a streaming card is forwarded with `message: null` on the `ccCardActionClicked` bus; the persisted bubble that follows is the source of truth.
+
+## Handling card actions
+
+The Cards renderer emits actions but never executes them. The UIKit forwards each action **untouched** on `CometChatMessageEvents.ccCardActionClicked`. Subscribe **once** at app startup and dispatch by action type.
+
+### The event payload
+
+```typescript
+export interface ICardActionEvent {
+  /**
+   * The owning message — CardMessage (developer) or AIAssistantMessage
+   * (persisted agent card). null only for a card tapped while the agent run
+   * is still streaming.
+   */
+  message: CometChat.BaseMessage | null;
+  /** The renderer's raw discriminated action (CometChatCardAction). */
+  action: unknown;
+  /** The renderer element id that emitted the action (used by customCallback). */
+  elementId?: string;
+  /** The raw card JSON the action originated from (used by customCallback). */
+  cardJson?: string;
+}
+```
+
+### Action types
+
+`action` is a `CometChatCardAction` — a discriminated union (from `@cometchat/cards-angular`) narrowed by its `type`. The UIKit forwards all of them; your app decides what each one does:
+
+| `type` | Intended behavior |
+| --- | --- |
+| `openUrl` | Open a URL (in a new tab or a webview). |
+| `copyToClipboard` | Copy a value to the clipboard. |
+| `downloadFile` | Download a file. |
+| `sendMessage` | Send a text message to a user/group (or the current conversation). |
+| `apiCall` | Make an HTTP request. |
+| `chatWithUser` | Open a one-to-one chat with a user. |
+| `chatWithGroup` | Open a group chat. |
+| `initiateCall` | Start an audio/video call. |
+| `customCallback` | Invoke an app-defined handler, keyed by `callbackId`. |
+
+### Reference handler
+
+Subscribe once (a root-provided service is the natural home) and dispatch by `type`. The snippet below mirrors the sample app's reference implementation:
+
+```typescript expandable
+import { Injectable, DestroyRef, inject } from '@angular/core';
+import { CometChat } from '@cometchat/chat-sdk-javascript';
+import {
+  CometChatMessageEvents,
+  ICardActionEvent,
+} from '@cometchat/chat-uikit-angular';
+import type { CometChatCardAction } from '@cometchat/cards-angular';
+
+/** Narrows the discriminated card action union to one variant by its type. */
+type Action<T extends CometChatCardAction['type']> = Extract<CometChatCardAction, { type: T }>;
+
+@Injectable({ providedIn: 'root' })
+export class CardActionService {
+  private readonly destroyRef = inject(DestroyRef);
+  private started = false;
+
+  /** Subscribe once. Idempotent; auto-unsubscribes when the injector is destroyed. */
+  start(): void {
+    if (this.started) return;
+    this.started = true;
+    CometChatMessageEvents.subscribeOnCardActionClicked(
+      (event) => this.dispatch(event),
+      this.destroyRef
+    );
+  }
+
+  private dispatch(event: ICardActionEvent): void {
+    const action = event.action as CometChatCardAction | null | undefined;
+    if (!action || typeof action !== 'object') return;
+
+    switch (action.type) {
+      case 'openUrl':
+        this.openUrl(action);
+        break;
+      case 'copyToClipboard':
+        this.copyToClipboard(action);
+        break;
+      case 'chatWithUser':
+        void this.chatWithUser(action);
+        break;
+      // ...handle downloadFile, sendMessage, apiCall, chatWithGroup,
+      //    initiateCall, and customCallback the same way.
+      default:
+        break; // Unknown action — the renderer owns the action vocabulary.
+    }
+  }
+
+  private openUrl(a: Action<'openUrl'>): void {
+    if (!a.url) return;
+    const target = a.openIn === 'webview' ? '_self' : '_blank';
+    window.open(a.url, target, 'noopener,noreferrer');
+  }
+
+  private copyToClipboard(a: Action<'copyToClipboard'>): void {
+    if (a.value == null) return;
+    navigator.clipboard?.writeText(a.value);
+  }
+
+  private async chatWithUser(a: Action<'chatWithUser'>): Promise<void> {
+    if (!a.uid) return;
+    const user = await CometChat.getUser(a.uid);
+    // Navigate your app to the conversation with `user`.
+  }
+}
+```
+
+Start the service once your shell is ready — for example from your home component's `ngOnInit`:
+
+```typescript
+export class HomeComponent implements OnInit {
+  constructor(private cardActions: CardActionService) {}
+
+  ngOnInit(): void {
+    this.cardActions.start();
+  }
+}
+```
+
+<Warning>
+  Each tap is forwarded on **one** bus to all subscribers. Subscribe in a single place (a root service) so an action runs exactly once. If you also bind the [`(onCardAction)` output](/ui-kit/angular/components/cometchat-card-bubble#card-actions) on a directly-rendered card bubble, handle the action on only one of the two channels.
+</Warning>
+
+### `customCallback` actions
+
+A `customCallback` action carries a `callbackId` (and optional `payload`). Map each `callbackId` to an app-defined handler, and use `event.elementId` / `event.cardJson` / `event.message?.getId()` for context. No server message is sent by the UIKit for a custom callback — it is entirely app-defined.
+
+## Fallback behavior
+
+Every card surface resolves a single-line fallback when the payload is empty or invalid:
+
+1. `getFallbackText()` (when available on the message/element)
+2. `getText()`
+3. Localized `"Card Message"`
+
+This guarantees a readable conversation even when a card cannot be rendered.
+
+## Related
+
+- **[Card Bubble](/ui-kit/angular/components/cometchat-card-bubble)** — the developer card component reference.
+- **[AI Assistant Chat](/ui-kit/angular/components/cometchat-ai-assistant-chat)** — the agent chat experience that renders persisted and streaming agent cards.
+- **[Events](/ui-kit/angular/events)** — `ccCardActionClicked` and `onCardMessageReceived` reference.

--- a/ui-kit/angular/guides/card-messages.mdx
+++ b/ui-kit/angular/guides/card-messages.mdx
@@ -9,7 +9,7 @@ description: "How the Angular UIKit renders Card Messages — developer cards, p
 | --- | --- |
 | Package | `@cometchat/chat-uikit-angular` |
 | Renderer | `@cometchat/cards-angular` (`CometChatCardView`) |
-| Components | `CometChatCardBubble`, `CometChatAIAssistantMessageBubble`, `CometChatStreamMessageBubble` |
+| Components | `CometChatCardBubbleComponent`, `CometChatAIAssistantMessageBubble`, `CometChatStreamMessageBubble` |
 | Key event | `CometChatMessageEvents.ccCardActionClicked` |
 | Required setup | `CometChatUIKit.init(uiKitSettings)` then `CometChatUIKit.login("UID")` |
 | Purpose | Render structured, interactive card payloads inside conversations and forward card actions to your app |
@@ -27,7 +27,7 @@ Card Messages are structured, interactive cards delivered inside conversations. 
 
 The UIKit is a **render-only** consumer of cards. For every card surface, the rules are identical:
 
-1. **Pass the payload through unchanged.** The raw card payload is read from the SDK, serialized verbatim (`JSON.stringify`), and handed to `CometChatCardView` as a `cardJson` string. The UIKit performs **no transformation**.
+1. **Pass the payload through unchanged.** The raw card payload is read from the SDK and handed to `CometChatCardView` as a `cardJson` string — an object payload is serialized with `JSON.stringify`, while a payload that is already a string is passed through as-is. The UIKit performs **no transformation**.
 2. **Forward actions, run no behavior.** The renderer emits actions through callbacks. The UIKit forwards them on the `ccCardActionClicked` event bus. Your app implements **all** behavior (open a URL, start a chat, call an API, …).
 3. **Fall back gracefully.** When a payload is empty or invalid, a single fallback line is shown instead of a broken card.
 
@@ -39,34 +39,38 @@ A card can reach the conversation in three ways. The UIKit routes each one to th
 
 | Path | Source | Component | Routed by |
 | --- | --- | --- | --- |
-| **Developer card** | `CardMessage` with `category: "card"` | [`CometChatCardBubble`](/ui-kit/angular/components/cometchat-card-bubble) | message **category** |
+| **Developer card** | `CardMessage` with `category: "card"` | [`CometChatCardBubbleComponent`](/ui-kit/angular/components/cometchat-card-bubble) | message **category** |
 | **Persisted agent card** | `AIAssistantMessage` content block | `CometChatAIAssistantMessageBubble` | element `type: "card"` |
 | **Streaming agent card** | Live `card_start` / `card` / `card_end` events | `CometChatStreamMessageBubble` | stream event type |
 
 ### Developer cards
 
-A message with category `"card"` is routed to `CometChatCardBubble` by [`CometChatMessageBubble`](/ui-kit/angular/components/cometchat-message-bubble), keyed on **category** (the developer `type` is arbitrary). The bubble renders `message.getCard()` and forwards taps on the `ccCardActionClicked` bus.
+A message with category `"card"` is routed to `CometChatCardBubbleComponent` by [`CometChatMessageBubble`](/ui-kit/angular/components/cometchat-message-bubble), keyed on **category** (the developer `type` is arbitrary). The bubble renders `message.getCard()` and forwards taps on the `ccCardActionClicked` bus.
 
 In the conversation list, a card message's preview is its `getText()` if present, otherwise the localized `"Card Message"` label.
 
 To react to incoming developer cards in real time, listen on the message bus:
 
 ```typescript expandable
-import { Injectable, DestroyRef, inject } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { CometChat } from '@cometchat/chat-sdk-javascript';
 import { CometChatMessageEvents } from '@cometchat/chat-uikit-angular';
+import { Subscription } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
-export class CardListener {
-  private readonly destroyRef = inject(DestroyRef);
+export class CardListener implements OnDestroy {
+  private cardSub?: Subscription;
 
   start(): void {
-    CometChatMessageEvents.subscribeOnCardMessageReceived(
+    this.cardSub = CometChatMessageEvents.onCardMessageReceived.subscribe(
       (card: CometChat.CardMessage) => {
         console.log('Card received:', card.getId(), card.getCard());
-      },
-      this.destroyRef
+      }
     );
+  }
+
+  ngOnDestroy(): void {
+    this.cardSub?.unsubscribe();
   }
 }
 ```
@@ -80,7 +84,7 @@ After an AI agent run completes, the persisted `AIAssistantMessage` exposes its 
 - a `text` block renders as Markdown (via [`CometChatMarkdownRenderer`](/ui-kit/angular/components/cometchat-markdown-renderer));
 - a `card` block renders through `CometChatCardView`, using the same render-only path as developer cards.
 
-When a message has no elements (older messages), the bubble falls back to `getText()`. No additional wiring is required — the [AI Assistant Chat](/ui-kit/angular/components/cometchat-ai-assistant-chat) flow instantiates this bubble for you. Taps on a nested agent card are forwarded on the same `ccCardActionClicked` bus.
+When a message has no elements (older messages), the bubble falls back to `getAssistantMessageData().getText()`. No additional wiring is required — the [AI Assistant Chat](/ui-kit/angular/components/cometchat-ai-assistant-chat) flow instantiates this bubble for you. Taps on a nested agent card are forwarded on the same `ccCardActionClicked` bus.
 
 ### Streaming agent cards
 
@@ -138,30 +142,34 @@ export interface ICardActionEvent {
 Subscribe once (a root-provided service is the natural home) and dispatch by `type`. The snippet below mirrors the sample app's reference implementation:
 
 ```typescript expandable
-import { Injectable, DestroyRef, inject } from '@angular/core';
+import { Injectable, OnDestroy } from '@angular/core';
 import { CometChat } from '@cometchat/chat-sdk-javascript';
 import {
   CometChatMessageEvents,
   ICardActionEvent,
 } from '@cometchat/chat-uikit-angular';
 import type { CometChatCardAction } from '@cometchat/cards-angular';
+import { Subscription } from 'rxjs';
 
 /** Narrows the discriminated card action union to one variant by its type. */
 type Action<T extends CometChatCardAction['type']> = Extract<CometChatCardAction, { type: T }>;
 
 @Injectable({ providedIn: 'root' })
-export class CardActionService {
-  private readonly destroyRef = inject(DestroyRef);
+export class CardActionService implements OnDestroy {
+  private actionSub?: Subscription;
   private started = false;
 
-  /** Subscribe once. Idempotent; auto-unsubscribes when the injector is destroyed. */
+  /** Subscribe once. Idempotent; unsubscribe in ngOnDestroy. */
   start(): void {
     if (this.started) return;
     this.started = true;
-    CometChatMessageEvents.subscribeOnCardActionClicked(
-      (event) => this.dispatch(event),
-      this.destroyRef
+    this.actionSub = CometChatMessageEvents.ccCardActionClicked.subscribe(
+      (event) => this.dispatch(event)
     );
+  }
+
+  ngOnDestroy(): void {
+    this.actionSub?.unsubscribe();
   }
 
   private dispatch(event: ICardActionEvent): void {
@@ -226,13 +234,13 @@ A `customCallback` action carries a `callbackId` (and optional `payload`). Map e
 
 ## Fallback behavior
 
-Every card surface resolves a single-line fallback when the payload is empty or invalid:
+When a payload is empty or invalid, a single fallback line is shown instead of a broken card. The exact resolution depends on the surface:
 
-1. `getFallbackText()` (when available on the message/element)
-2. `getText()`
-3. Localized `"Card Message"`
+- **Developer card** — `getFallbackText()` → `getText()` → localized `"Card Message"`.
+- **Persisted agent card** — the card's own `fallbackText` → localized `"Card Message"`.
+- **Streaming agent card** — no fallback line; an empty streamed card is simply not rendered (the run-complete persisted message is the source of truth).
 
-This guarantees a readable conversation even when a card cannot be rendered.
+This keeps the conversation readable even when a card cannot be rendered.
 
 ## Related
 


### PR DESCRIPTION
Render-only Card Message support in the Angular UIKit.

- components/cometchat-card-bubble.mdx: new developer card bubble reference (render-only contract, inputs, onCardAction/ccCardActionClicked, fallback)
- guides/card-messages.mdx: new guide — three delivery paths (developer, persisted agent, streaming agent) and the card action vocabulary
- events.mdx: add ccCardActionClicked and onCardMessageReceived
- docs.json: register the new pages in the Angular nav

## Description

<!-- Please include a summary of the changes and relevant context. -->

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [ ] Documentation correction/update
- [ ] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [ ] My changes follow the documentation style guide
- [ ] I have checked for spelling and grammar errors
- [ ] All links in my changes are valid and working
- [ ] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
