### PR TITLE
docs(js-sdk): document card message support (ENG-36071)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3189,6 +3189,7 @@
                             "pages": [
                               "sdk/javascript/send-message",
                               "sdk/javascript/receive-message",
+                              "sdk/javascript/card-messages",
                               "sdk/javascript/message-filtering",
                               "sdk/javascript/retrieve-conversations",
                               "sdk/javascript/threaded-messages",

--- a/sdk/javascript/ai-agents.mdx
+++ b/sdk/javascript/ai-agents.mdx
@@ -131,6 +131,14 @@ Each message type extends [`BaseMessage`](/sdk/reference/messages#basemessage) a
 | `AIToolResultMessage`   | `getToolResultMessageData()`   | `getRunId()`, `getThreadId()`, `getText()`, `getToolCallId()` |
 | `AIToolArgumentMessage` | `getToolArgumentMessageData()` | `getRunId()`, `getThreadId()`, `getToolCalls()`               |
 
+<Note>
+  When an agent reply contains a card, the card is embedded inline in the
+  `AIAssistantMessage` and exposed through `getElements()`. Cards are also
+  streamed in real time via the `card_start` / `card` / `card_end` events on
+  the `AIAssistantListener`. See the [Card Messages
+  guide](/sdk/javascript/card-messages) for both flows.
+</Note>
+
 The `getToolCalls()` method on `AIToolArgumentMessage` returns an array of `AIToolCall` objects, each with:
 
 | Getter               | Return Type          | Description                                           |

--- a/sdk/javascript/all-real-time-listeners.mdx
+++ b/sdk/javascript/all-real-time-listeners.mdx
@@ -310,6 +310,7 @@ Receive events for incoming messages, typing indicators, read/delivery receipts,
 | **onAIAssistantMessageReceived(message: CometChat.AIAssistantMessage)** | This event is triggered when a persisted AI assistant reply is received after an agent run completes.                                                                |
 | **onAIToolResultReceived(message: CometChat.AIToolResultMessage)**      | This event is triggered when a persisted AI tool result message is received after an agent run completes.                                                            |
 | **onAIToolArgumentsReceived(message: CometChat.AIToolArgumentMessage)** | This event is triggered when a persisted AI tool argument message is received after an agent run completes.                                                          |
+| **onCardMessageReceived(message: CometChat.CardMessage)**               | This event is triggered when a standalone [card message](/sdk/javascript/card-messages) is received.                                                                 |
 
 To add the `MessageListener`, you need to use the `addMessageListener()` method provided by the `CometChat` class.
 
@@ -372,6 +373,9 @@ CometChat.addMessageListener(
     },
     onAIToolArgumentsReceived: (message: CometChat.AIToolArgumentMessage) => {
       console.log("AI Tool arguments received", message);
+    },
+    onCardMessageReceived: (message: CometChat.CardMessage) => {
+      console.log("Card message received", message);
     },
   })
 );
@@ -437,6 +441,9 @@ CometChat.addMessageListener(
     },
     onAIToolArgumentsReceived: (message) => {
       console.log("AI Tool arguments received", message);
+    },
+    onCardMessageReceived: (message) => {
+      console.log("Card message received", message);
     },
   })
 );
@@ -565,7 +572,15 @@ The `AIAssistantListener` provides real-time streaming events from AI Agent runs
 
 | Method                                                                | Information                                                                                                                                                                                                                                |
 | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **onAIAssistantEventReceived(event: CometChat.AIAssistantBaseEvent)** | This event is triggered for each streaming event during an AI Agent run (run start, tool calls, text message streaming, run finished). See [`AIAssistantBaseEvent`](/sdk/reference/messages#aiassistantbaseevent) for the event structure. |
+| **onAIAssistantEventReceived(event: CometChat.AIAssistantBaseEvent)** | This event is triggered for each streaming event during an AI Agent run (run start, tool calls, text message streaming, card streaming, run finished). See [`AIAssistantBaseEvent`](/sdk/reference/messages#aiassistantbaseevent) for the event structure. |
+
+<Note>
+  Card streaming (`card_start`, `card`, `card_end`) is delivered through this
+  same callback as [`AIAssistantCardStartedEvent`](/sdk/reference/messages#aiassistantcardstartedevent),
+  [`AIAssistantCardReceivedEvent`](/sdk/reference/messages#aiassistantcardreceivedevent), and
+  [`AIAssistantCardEndedEvent`](/sdk/reference/messages#aiassistantcardendedevent). See the
+  [Card Messages guide](/sdk/javascript/card-messages#real-time-card-streaming-events).
+</Note>
 
 <Tabs>
 <Tab title="TypeScript">

--- a/sdk/javascript/card-messages.mdx
+++ b/sdk/javascript/card-messages.mdx
@@ -91,7 +91,51 @@ CometChat.addMessageListener(
 
 ### Rendering a Card Message
 
-Read the card payload with `getCard()`, and fall back to `getFallbackText()` (or `getText()`) when it is missing or your app cannot render it:
+Every flow on this page draws a card by handing its raw JSON to the `CometChatCardView` renderer (`@cometchat/cards-react`, the same component used for feed cards). Define the renderer once and reuse it wherever a card needs to be drawn:
+
+<Tabs>
+<Tab title="TypeScript">
+```tsx
+import { CometChatCardView } from "@cometchat/cards-react";
+
+// Renders a raw Card Schema JSON object with the CometChat Cards renderer.
+function renderCardView(card: object) {
+  return (
+    <CometChatCardView
+      cardJson={JSON.stringify(card)}
+      themeMode="auto"
+      onAction={(event) => {
+        // Handle card taps/buttons — see Supported Card Actions.
+      }}
+    />
+  );
+}
+```
+
+</Tab>
+
+<Tab title="JavaScript">
+```jsx
+import { CometChatCardView } from "@cometchat/cards-react";
+
+// Renders a raw Card Schema JSON object with the CometChat Cards renderer.
+function renderCardView(card) {
+  return (
+    <CometChatCardView
+      cardJson={JSON.stringify(card)}
+      themeMode="auto"
+      onAction={(event) => {
+        // Handle card taps/buttons — see Supported Card Actions.
+      }}
+    />
+  );
+}
+```
+
+</Tab>
+</Tabs>
+
+Then read the card payload with `getCard()`, and fall back to `getFallbackText()` (or `getText()`) when it is missing or your app cannot render it:
 
 <Tabs>
 <Tab title="TypeScript">
@@ -105,8 +149,8 @@ function renderCard(cardMessage: CometChat.CardMessage): void {
     return;
   }
 
-  // `card` is the raw JSON your platform sent. Map it to your UI here.
-  showCardUI(card, cardMessage.getFallbackText());
+  // Hand the raw Card Schema JSON to the CometChat Cards renderer.
+  renderCardView(card);
 }
 ```
 
@@ -123,8 +167,8 @@ function renderCard(cardMessage) {
     return;
   }
 
-  // `card` is the raw JSON your platform sent. Map it to your UI here.
-  showCardUI(card, cardMessage.getFallbackText());
+  // Hand the raw Card Schema JSON to the CometChat Cards renderer.
+  renderCardView(card);
 }
 ```
 
@@ -193,7 +237,7 @@ CometChat.addMessageListener(
             break;
           case "card": {
             const { card, cardId } = element.getData(); // { card, cardId }
-            showCardUI(card, cardId);
+            renderCardView(card);
             break;
           }
           default:
@@ -229,7 +273,7 @@ CometChat.addMessageListener(
             break;
           case "card": {
             const { card, cardId } = element.getData(); // { card, cardId }
-            showCardUI(card, cardId);
+            renderCardView(card);
             break;
           }
           default:
@@ -286,7 +330,7 @@ CometChat.addAIAssistantListener(listenerID, {
       case "card": {
         const received = event as CometChat.AIAssistantCardReceivedEvent;
         // The full payload is ready — render it.
-        showCardUI(received.getCard(), received.getCardId());
+        renderCardView(received.getCard());
         break;
       }
       case "card_end": {
@@ -317,7 +361,7 @@ CometChat.addAIAssistantListener(listenerID, {
         break;
       case "card":
         // The full payload is ready — render it.
-        showCardUI(event.getCard(), event.getCardId());
+        renderCardView(event.getCard());
         break;
       case "card_end":
         finalizeCard(event.getCardId());

--- a/sdk/javascript/card-messages.mdx
+++ b/sdk/javascript/card-messages.mdx
@@ -13,7 +13,7 @@ The body of a card is **Card Schema JSON** — the same structured layout used b
   responsibility: pass that JSON to the **CometChat Cards** renderer for your
   framework.
 
-  - **React** — [`@cometchat/cards-react`](https://www.npmjs.com/package/@cometchat/cards-react) (`CometChatCardView`): see [Rendering Cards](/sdk/javascript/campaigns#rendering-cards) and [Supported Card Actions](/sdk/javascript/campaigns#supported-card-actions).
+  - **React** — [`@cometchat/cards-react`](https://www.npmjs.com/package/@cometchat/cards-react) (`CometChatCardView`): see [Card Messages](/ui-kit/react/v6/card-messages#the-render-only-contract).
   - **Angular** — [`@cometchat/cards-angular`](https://www.npmjs.com/package/@cometchat/cards-angular) (`CometChatCardView`): see [Card Messages](/ui-kit/angular/guides/card-messages#the-render-only-contract).
   - **Vanilla / any framework** — [`@cometchat/cards`](https://www.npmjs.com/package/@cometchat/cards).
 </Note>

--- a/sdk/javascript/card-messages.mdx
+++ b/sdk/javascript/card-messages.mdx
@@ -8,13 +8,14 @@ Card messages let your app display rich, structured content — such as product 
 The body of a card is **Card Schema JSON** — the same structured layout used by [Campaigns notification feeds](/sdk/javascript/campaigns). Cards are authored server-side (they cannot be composed or sent from the SDK) via the [Platform (REST) API](/rest-api/messages/send-message) or the **Dashboard Bubble Builder**, and delivered to clients like any other message.
 
 <Note>
-  The SDK never interprets the body of a card — every card accessor returns the
-  raw Card Schema JSON exactly as it was sent. To draw it natively, pass that
-  JSON to the CometChat Cards renderer (`@cometchat/cards-react` →
-  `CometChatCardView`), the same component used for feed cards. See
-  [Campaigns → Rendering Cards](/sdk/javascript/campaigns#rendering-cards) for
-  dependency setup and [Supported Card Actions](/sdk/javascript/campaigns#supported-card-actions)
-  for handling taps and buttons.
+  The SDK never interprets the body of a card — every accessor returns the raw
+  Card Schema JSON exactly as it was sent. Drawing it is your app's
+  responsibility: pass that JSON to the **CometChat Cards** renderer for your
+  framework.
+
+  - **React** — [`@cometchat/cards-react`](https://www.npmjs.com/package/@cometchat/cards-react) (`CometChatCardView`): see [Rendering Cards](/sdk/javascript/campaigns#rendering-cards) and [Supported Card Actions](/sdk/javascript/campaigns#supported-card-actions).
+  - **Angular** — [`@cometchat/cards-angular`](https://www.npmjs.com/package/@cometchat/cards-angular) (`CometChatCardView`): see [Card Messages](/ui-kit/angular/guides/card-messages#the-render-only-contract).
+  - **Vanilla / any framework** — [`@cometchat/cards`](https://www.npmjs.com/package/@cometchat/cards).
 </Note>
 
 ## How Cards Arrive
@@ -62,8 +63,9 @@ CometChat.addMessageListener(
   listenerID,
   new CometChat.MessageListener({
     onCardMessageReceived: (cardMessage: CometChat.CardMessage) => {
-      console.log("Card message received successfully", cardMessage);
-      renderCard(cardMessage);
+      console.log("Card message received", cardMessage);
+      // getCard() returns the raw Card Schema JSON — pass it to your card renderer.
+      const card = cardMessage.getCard();
     },
   })
 );
@@ -79,8 +81,9 @@ CometChat.addMessageListener(
   listenerID,
   new CometChat.MessageListener({
     onCardMessageReceived: (cardMessage) => {
-      console.log("Card message received successfully", cardMessage);
-      renderCard(cardMessage);
+      console.log("Card message received", cardMessage);
+      // getCard() returns the raw Card Schema JSON — pass it to your card renderer.
+      const card = cardMessage.getCard();
     },
   })
 );
@@ -91,89 +94,7 @@ CometChat.addMessageListener(
 
 ### Rendering a Card Message
 
-Every flow on this page draws a card by handing its raw JSON to the `CometChatCardView` renderer (`@cometchat/cards-react`, the same component used for feed cards). Define the renderer once and reuse it wherever a card needs to be drawn:
-
-<Tabs>
-<Tab title="TypeScript">
-```tsx
-import { CometChatCardView } from "@cometchat/cards-react";
-
-// Renders a raw Card Schema JSON object with the CometChat Cards renderer.
-function renderCardView(card: object) {
-  return (
-    <CometChatCardView
-      cardJson={JSON.stringify(card)}
-      themeMode="auto"
-      onAction={(event) => {
-        // Handle card taps/buttons — see Supported Card Actions.
-      }}
-    />
-  );
-}
-```
-
-</Tab>
-
-<Tab title="JavaScript">
-```jsx
-import { CometChatCardView } from "@cometchat/cards-react";
-
-// Renders a raw Card Schema JSON object with the CometChat Cards renderer.
-function renderCardView(card) {
-  return (
-    <CometChatCardView
-      cardJson={JSON.stringify(card)}
-      themeMode="auto"
-      onAction={(event) => {
-        // Handle card taps/buttons — see Supported Card Actions.
-      }}
-    />
-  );
-}
-```
-
-</Tab>
-</Tabs>
-
-Then read the card payload with `getCard()`, and fall back to `getFallbackText()` (or `getText()`) when it is missing or your app cannot render it:
-
-<Tabs>
-<Tab title="TypeScript">
-```typescript
-function renderCard(cardMessage: CometChat.CardMessage): void {
-  const card: any = cardMessage.getCard();
-
-  if (!card) {
-    // Nothing to render — show the fallback text instead.
-    showText(cardMessage.getFallbackText() || cardMessage.getText());
-    return;
-  }
-
-  // Hand the raw Card Schema JSON to the CometChat Cards renderer.
-  renderCardView(card);
-}
-```
-
-</Tab>
-
-<Tab title="JavaScript">
-```javascript
-function renderCard(cardMessage) {
-  const card = cardMessage.getCard();
-
-  if (!card) {
-    // Nothing to render — show the fallback text instead.
-    showText(cardMessage.getFallbackText() || cardMessage.getText());
-    return;
-  }
-
-  // Hand the raw Card Schema JSON to the CometChat Cards renderer.
-  renderCardView(card);
-}
-```
-
-</Tab>
-</Tabs>
+`getCard()` returns the raw Card Schema JSON — turning it into UI is your app's job. Pass that JSON to the CometChat Cards renderer for your framework (see the note at the top of this page), and fall back to `getFallbackText()` — then `getText()` — when the card is absent or cannot be rendered.
 
 A card payload is arbitrary JSON. A typical shape looks like this — but treat the structure as opaque and render whatever fields your platform sends:
 
@@ -226,22 +147,23 @@ CometChat.addMessageListener(
 
       if (elements.length === 0) {
         // Older message with no elements — fall back to the plain text reply.
-        showText(message.getAssistantMessageData().getText());
+        console.log("Message text:", message.getAssistantMessageData().getText());
         return;
       }
 
       elements.forEach((element: CometChat.AIAssistantElement) => {
         switch (element.getType()) {
           case "text":
-            showText(element.getData()); // a string
+            console.log("Text block:", element.getData()); // a string
             break;
           case "card": {
             const { card, cardId } = element.getData(); // { card, cardId }
-            renderCardView(card);
+            console.log("Card block:", cardId);
+            // Pass the card to your card renderer.
             break;
           }
           default:
-            // Unknown element type — ignore or render a placeholder.
+            console.log("Unknown element type:", element.getType());
             break;
         }
       });
@@ -262,22 +184,23 @@ CometChat.addMessageListener(
 
       if (elements.length === 0) {
         // Older message with no elements — fall back to the plain text reply.
-        showText(message.getAssistantMessageData().getText());
+        console.log("Message text:", message.getAssistantMessageData().getText());
         return;
       }
 
       elements.forEach((element) => {
         switch (element.getType()) {
           case "text":
-            showText(element.getData()); // a string
+            console.log("Text block:", element.getData()); // a string
             break;
           case "card": {
             const { card, cardId } = element.getData(); // { card, cardId }
-            renderCardView(card);
+            console.log("Card block:", cardId);
+            // Pass the card to your card renderer.
             break;
           }
           default:
-            // Unknown element type — ignore or render a placeholder.
+            console.log("Unknown element type:", element.getType());
             break;
         }
       });
@@ -323,19 +246,20 @@ CometChat.addAIAssistantListener(listenerID, {
     switch (event.getType()) {
       case "card_start": {
         const started = event as CometChat.AIAssistantCardStartedEvent;
-        // Show a placeholder while the card is being generated.
-        showCardPlaceholder(started.getCardId(), started.getExecutionText());
+        console.log("Card generation started:", started.getCardId());
+        console.log("Execution text:", started.getExecutionText());
         break;
       }
       case "card": {
         const received = event as CometChat.AIAssistantCardReceivedEvent;
-        // The full payload is ready — render it.
-        renderCardView(received.getCard());
+        console.log("Card received:", received.getCardId());
+        const cardPayload = received.getCard();
+        // Pass cardPayload to your card renderer.
         break;
       }
       case "card_end": {
         const ended = event as CometChat.AIAssistantCardEndedEvent;
-        finalizeCard(ended.getCardId());
+        console.log("Card generation ended:", ended.getCardId());
         break;
       }
       default:
@@ -356,15 +280,17 @@ CometChat.addAIAssistantListener(listenerID, {
   onAIAssistantEventReceived: (event) => {
     switch (event.getType()) {
       case "card_start":
-        // Show a placeholder while the card is being generated.
-        showCardPlaceholder(event.getCardId(), event.getExecutionText());
+        console.log("Card generation started:", event.getCardId());
+        console.log("Execution text:", event.getExecutionText());
         break;
-      case "card":
-        // The full payload is ready — render it.
-        renderCardView(event.getCard());
+      case "card": {
+        console.log("Card received:", event.getCardId());
+        const cardPayload = event.getCard();
+        // Pass cardPayload to your card renderer.
         break;
+      }
       case "card_end":
-        finalizeCard(event.getCardId());
+        console.log("Card generation ended:", event.getCardId());
         break;
       default:
         // Other agent stream events (run/tool/text) — handle as needed.

--- a/sdk/javascript/card-messages.mdx
+++ b/sdk/javascript/card-messages.mdx
@@ -13,7 +13,7 @@ The body of a card is **Card Schema JSON** — the same structured layout used b
   responsibility: pass that JSON to the **CometChat Cards** renderer for your
   framework.
 
-  - **React** — please refer to the [Card Messages](/ui-kit/react/v6/card-messages#the-render-only-contract) guide.
+  - **React** — please refer to the [Card Messages](/ui-kit/react/v7/card-messages#the-render-only-contract) guide.
   - **Angular** — please refer to the [Card Messages](/ui-kit/angular/guides/card-messages#the-render-only-contract) guide.
 </Note>
 

--- a/sdk/javascript/card-messages.mdx
+++ b/sdk/javascript/card-messages.mdx
@@ -5,11 +5,16 @@ description: "Receive and render rich card messages with the CometChat JavaScrip
 
 Card messages let your app display rich, structured content — such as product cards, confirmations, or AI-generated summaries — inside a conversation. In the JavaScript SDK, card support is **receive-only**: the SDK deserializes incoming cards and hands you their raw payload through typed accessors, and your app is responsible for turning that payload into UI.
 
+The body of a card is **Card Schema JSON** — the same structured layout used by [Campaigns notification feeds](/sdk/javascript/campaigns). Cards are authored server-side (they cannot be composed or sent from the SDK) via the [Platform (REST) API](/rest-api/messages/send-message) or the **Dashboard Bubble Builder**, and delivered to clients like any other message.
+
 <Note>
-  The SDK never interprets the body of a card. Every card accessor returns the
-  raw JSON exactly as it was sent, so you are free to render it however your
-  design system requires. Cards cannot currently be composed or sent from the
-  SDK.
+  The SDK never interprets the body of a card — every card accessor returns the
+  raw Card Schema JSON exactly as it was sent. To draw it natively, pass that
+  JSON to the CometChat Cards renderer (`@cometchat/cards-react` →
+  `CometChatCardView`), the same component used for feed cards. See
+  [Campaigns → Rendering Cards](/sdk/javascript/campaigns#rendering-cards) for
+  dependency setup and [Supported Card Actions](/sdk/javascript/campaigns#supported-card-actions)
+  for handling taps and buttons.
 </Note>
 
 ## How Cards Arrive
@@ -35,13 +40,14 @@ A standalone card arrives as a message whose category is `card` (its type is `te
   `getType()` returns `"text"`, the same as a plain text message.
 </Note>
 
-`CardMessage` extends [`BaseMessage`](/sdk/reference/messages#basemessage), so all the usual metadata (`getSender()`, `getReceiver()`, `getSentAt()`, `getConversationId()`, …) is available. It adds three card-specific accessors:
+`CardMessage` extends [`BaseMessage`](/sdk/reference/messages#basemessage), so all the usual metadata (`getSender()`, `getReceiver()`, `getSentAt()`, `getConversationId()`, …) is available. It adds these card-specific accessors:
 
 | Getter              | Return Type          | Description                                                                        |
 | ------------------- | -------------------- | --------------------------------------------------------------------------------- |
-| `getCard()`         | `Object \| undefined`| The raw card JSON object (`data.card`). Returns `undefined` when no card is present. |
-| `getText()`         | `string`             | The plain-text content that accompanies the card (`data.text`).                   |
+| `getCard()`         | `Object \| undefined`| The raw Card Schema JSON object (`data.card`). Returns `undefined` when no card is present. |
+| `getText()`         | `string`             | The plain-text content that accompanies the card (`data.text`), used as preview text in the conversation list and push notifications. |
 | `getFallbackText()` | `string`             | Text to display when the card cannot be rendered (`card.fallbackText`).           |
+| `getTags()`         | `Array<String>`      | Tags associated with the message.                                                 |
 
 ### Receiving a Card Message
 
@@ -152,10 +158,13 @@ The ordered content of an assistant reply is exposed through `getElements()`, wh
 | `getData()`  | `any`       | The element's raw body. For `"text"` it is the text string; for `"card"` it is `{ card, cardId }`. |
 
 <Note>
-  `getElements()` returns an **empty array** for messages that predate this
-  feature (or that carry no elements). When the array is empty, render the reply
-  from `getAssistantMessageData().getText()` as before — the elements API is
-  purely additive and never breaks existing rendering.
+  When `getElements()` is non-empty, prefer it as the render source and walk the
+  blocks in order — a card-only reply may have an empty
+  `getAssistantMessageData().getText()`, so relying on the text alone can drop
+  content. `getElements()` returns an **empty array** only for messages that
+  predate this feature (or that carry no elements); in that case fall back to
+  `getAssistantMessageData().getText()`. The elements API is purely additive and
+  never breaks existing rendering.
 </Note>
 
 ### Rendering an Assistant Reply with Elements

--- a/sdk/javascript/card-messages.mdx
+++ b/sdk/javascript/card-messages.mdx
@@ -1,0 +1,376 @@
+---
+title: "Card Messages"
+description: "Receive and render rich card messages with the CometChat JavaScript SDK."
+---
+
+Card messages let your app display rich, structured content — such as product cards, confirmations, or AI-generated summaries — inside a conversation. In the JavaScript SDK, card support is **receive-only**: the SDK deserializes incoming cards and hands you their raw payload through typed accessors, and your app is responsible for turning that payload into UI.
+
+<Note>
+  The SDK never interprets the body of a card. Every card accessor returns the
+  raw JSON exactly as it was sent, so you are free to render it however your
+  design system requires. Cards cannot currently be composed or sent from the
+  SDK.
+</Note>
+
+## How Cards Arrive
+
+There are three ways a card can reach your app. Which one you handle depends on where the card originates.
+
+| Delivery                          | Listener / Callback                                         | Object                                                                                    | When to use                                                    |
+| --------------------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------- |
+| Standalone card message           | `MessageListener.onCardMessageReceived`                    | [`CardMessage`](/sdk/reference/messages#cardmessage)                                       | A card sent as a complete message on its own                  |
+| Inline card in an AI agent reply  | `MessageListener.onAIAssistantMessageReceived`             | [`AIAssistantMessage`](/sdk/reference/messages#aiassistantmessage) → `getElements()`       | A card embedded in a persisted AI Agent reply                 |
+| Real-time card streaming events   | `AIAssistantListener.onAIAssistantEventReceived`           | [`AIAssistantCardStartedEvent` / `...ReceivedEvent` / `...EndedEvent`](/sdk/reference/messages#aiassistantcardstartedevent) | Progressive rendering of a card while an AI Agent run streams |
+
+The sections below cover each of these in turn.
+
+---
+
+## Standalone Card Messages
+
+A standalone card arrives as a message whose category is `card` (its type is `text`). The SDK deserializes it into a [`CardMessage`](/sdk/reference/messages#cardmessage) and delivers it through the **`onCardMessageReceived`** callback of the [`MessageListener`](/sdk/javascript/all-real-time-listeners#message-listener).
+
+<Note>
+  Branch on `getCategory() === "card"` to identify a card message —
+  `getType()` returns `"text"`, the same as a plain text message.
+</Note>
+
+`CardMessage` extends [`BaseMessage`](/sdk/reference/messages#basemessage), so all the usual metadata (`getSender()`, `getReceiver()`, `getSentAt()`, `getConversationId()`, …) is available. It adds three card-specific accessors:
+
+| Getter              | Return Type          | Description                                                                        |
+| ------------------- | -------------------- | --------------------------------------------------------------------------------- |
+| `getCard()`         | `Object \| undefined`| The raw card JSON object (`data.card`). Returns `undefined` when no card is present. |
+| `getText()`         | `string`             | The plain-text content that accompanies the card (`data.text`).                   |
+| `getFallbackText()` | `string`             | Text to display when the card cannot be rendered (`card.fallbackText`).           |
+
+### Receiving a Card Message
+
+Register a `MessageListener` and implement `onCardMessageReceived`:
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+const listenerID: string = "UNIQUE_LISTENER_ID";
+
+CometChat.addMessageListener(
+  listenerID,
+  new CometChat.MessageListener({
+    onCardMessageReceived: (cardMessage: CometChat.CardMessage) => {
+      console.log("Card message received successfully", cardMessage);
+      renderCard(cardMessage);
+    },
+  })
+);
+```
+
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+const listenerID = "UNIQUE_LISTENER_ID";
+
+CometChat.addMessageListener(
+  listenerID,
+  new CometChat.MessageListener({
+    onCardMessageReceived: (cardMessage) => {
+      console.log("Card message received successfully", cardMessage);
+      renderCard(cardMessage);
+    },
+  })
+);
+```
+
+</Tab>
+</Tabs>
+
+### Rendering a Card Message
+
+Read the card payload with `getCard()`, and fall back to `getFallbackText()` (or `getText()`) when it is missing or your app cannot render it:
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+function renderCard(cardMessage: CometChat.CardMessage): void {
+  const card: any = cardMessage.getCard();
+
+  if (!card) {
+    // Nothing to render — show the fallback text instead.
+    showText(cardMessage.getFallbackText() || cardMessage.getText());
+    return;
+  }
+
+  // `card` is the raw JSON your platform sent. Map it to your UI here.
+  showCardUI(card, cardMessage.getFallbackText());
+}
+```
+
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+function renderCard(cardMessage) {
+  const card = cardMessage.getCard();
+
+  if (!card) {
+    // Nothing to render — show the fallback text instead.
+    showText(cardMessage.getFallbackText() || cardMessage.getText());
+    return;
+  }
+
+  // `card` is the raw JSON your platform sent. Map it to your UI here.
+  showCardUI(card, cardMessage.getFallbackText());
+}
+```
+
+</Tab>
+</Tabs>
+
+A card payload is arbitrary JSON. A typical shape looks like this — but treat the structure as opaque and render whatever fields your platform sends:
+
+```json
+{
+  "text": "Here is your order summary",
+  "card": {
+    "fallbackText": "Order #1234 — 2 items — $48.00",
+    "title": "Order #1234",
+    "components": []
+  }
+}
+```
+
+---
+
+## Inline Cards in AI Agent Replies
+
+When an [AI Agent](/sdk/javascript/ai-agents) produces a card, it is **not** delivered as a separate message. Instead it is embedded, in order, inside the agent's persisted reply — an [`AIAssistantMessage`](/sdk/reference/messages#aiassistantmessage) received through the existing **`onAIAssistantMessageReceived`** callback.
+
+The ordered content of an assistant reply is exposed through `getElements()`, which returns an array of [`AIAssistantElement`](/sdk/reference/messages#aiassistantelement) objects. Each element is a `{ type, value }` envelope:
+
+| Getter       | Return Type | Description                                                                                        |
+| ------------ | ----------- | ------------------------------------------------------------------------------------------------- |
+| `getType()`  | `string`    | The element type — `"text"`, `"card"`, or any other type your platform emits.                     |
+| `getData()`  | `any`       | The element's raw body. For `"text"` it is the text string; for `"card"` it is `{ card, cardId }`. |
+
+<Note>
+  `getElements()` returns an **empty array** for messages that predate this
+  feature (or that carry no elements). When the array is empty, render the reply
+  from `getAssistantMessageData().getText()` as before — the elements API is
+  purely additive and never breaks existing rendering.
+</Note>
+
+### Rendering an Assistant Reply with Elements
+
+Walk the elements in order and branch on `getType()`:
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+CometChat.addMessageListener(
+  "UNIQUE_LISTENER_ID",
+  new CometChat.MessageListener({
+    onAIAssistantMessageReceived: (message: CometChat.AIAssistantMessage) => {
+      const elements: CometChat.AIAssistantElement[] = message.getElements();
+
+      if (elements.length === 0) {
+        // Older message with no elements — fall back to the plain text reply.
+        showText(message.getAssistantMessageData().getText());
+        return;
+      }
+
+      elements.forEach((element: CometChat.AIAssistantElement) => {
+        switch (element.getType()) {
+          case "text":
+            showText(element.getData()); // a string
+            break;
+          case "card": {
+            const { card, cardId } = element.getData(); // { card, cardId }
+            showCardUI(card, cardId);
+            break;
+          }
+          default:
+            // Unknown element type — ignore or render a placeholder.
+            break;
+        }
+      });
+    },
+  })
+);
+```
+
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+CometChat.addMessageListener(
+  "UNIQUE_LISTENER_ID",
+  new CometChat.MessageListener({
+    onAIAssistantMessageReceived: (message) => {
+      const elements = message.getElements();
+
+      if (elements.length === 0) {
+        // Older message with no elements — fall back to the plain text reply.
+        showText(message.getAssistantMessageData().getText());
+        return;
+      }
+
+      elements.forEach((element) => {
+        switch (element.getType()) {
+          case "text":
+            showText(element.getData()); // a string
+            break;
+          case "card": {
+            const { card, cardId } = element.getData(); // { card, cardId }
+            showCardUI(card, cardId);
+            break;
+          }
+          default:
+            // Unknown element type — ignore or render a placeholder.
+            break;
+        }
+      });
+    },
+  })
+);
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Real-Time Card Streaming Events
+
+While an AI Agent run is in progress, cards are streamed as real-time events over the [`AIAssistantListener`](/sdk/javascript/all-real-time-listeners#ai-assistant-listener) so you can render (or show a placeholder for) a card before the persisted `AIAssistantMessage` arrives. These events are delivered through **`onAIAssistantEventReceived`** alongside the other [AI Agent stream events](/sdk/javascript/ai-agents#real-time-events).
+
+There are three card events, emitted in order per card:
+
+| Order | Event type   | Object                                                                              | Meaning                                    |
+| ----- | ------------ | ----------------------------------------------------------------------------------- | ------------------------------------------ |
+| 1     | `card_start` | [`AIAssistantCardStartedEvent`](/sdk/reference/messages#aiassistantcardstartedevent)   | The agent began generating a card          |
+| 2     | `card`       | [`AIAssistantCardReceivedEvent`](/sdk/reference/messages#aiassistantcardreceivedevent) | The full card payload is available         |
+| 3     | `card_end`   | [`AIAssistantCardEndedEvent`](/sdk/reference/messages#aiassistantcardendedevent)       | The card is finalized                      |
+
+Every card event extends [`AIAssistantBaseEvent`](/sdk/reference/messages#aiassistantbaseevent) (so it carries `getType()`, `getConversationId()`, `getRunId()`, etc.) and adds these card-specific getters:
+
+| Event                          | Extra Getters                                            | Description                                                    |
+| ------------------------------ | ------------------------------------------------------- | ------------------------------------------------------------- |
+| `AIAssistantCardStartedEvent`  | `getStreamMessageId()`, `getCardId()`, `getExecutionText()` | Stream/card IDs and the text shown while the card is generated |
+| `AIAssistantCardReceivedEvent` | `getStreamMessageId()`, `getCardId()`, `getCard()`      | Stream/card IDs and the raw card payload                       |
+| `AIAssistantCardEndedEvent`    | `getStreamMessageId()`, `getCardId()`                   | Stream/card IDs marking the end of the card                    |
+
+Use `getStreamMessageId()` / `getCardId()` to correlate the three events for the same card, and `getCard()` on the `card` event to obtain the payload to render.
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+const listenerID: string = "UNIQUE_LISTENER_ID";
+
+CometChat.addAIAssistantListener(listenerID, {
+  onAIAssistantEventReceived: (event: CometChat.AIAssistantBaseEvent) => {
+    switch (event.getType()) {
+      case "card_start": {
+        const started = event as CometChat.AIAssistantCardStartedEvent;
+        // Show a placeholder while the card is being generated.
+        showCardPlaceholder(started.getCardId(), started.getExecutionText());
+        break;
+      }
+      case "card": {
+        const received = event as CometChat.AIAssistantCardReceivedEvent;
+        // The full payload is ready — render it.
+        showCardUI(received.getCard(), received.getCardId());
+        break;
+      }
+      case "card_end": {
+        const ended = event as CometChat.AIAssistantCardEndedEvent;
+        finalizeCard(ended.getCardId());
+        break;
+      }
+      default:
+        // Other agent stream events (run/tool/text) — handle as needed.
+        break;
+    }
+  },
+});
+```
+
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+const listenerID = "UNIQUE_LISTENER_ID";
+
+CometChat.addAIAssistantListener(listenerID, {
+  onAIAssistantEventReceived: (event) => {
+    switch (event.getType()) {
+      case "card_start":
+        // Show a placeholder while the card is being generated.
+        showCardPlaceholder(event.getCardId(), event.getExecutionText());
+        break;
+      case "card":
+        // The full payload is ready — render it.
+        showCardUI(event.getCard(), event.getCardId());
+        break;
+      case "card_end":
+        finalizeCard(event.getCardId());
+        break;
+      default:
+        // Other agent stream events (run/tool/text) — handle as needed.
+        break;
+    }
+  },
+});
+```
+
+</Tab>
+</Tabs>
+
+<Note>
+  Streaming card events are the live view of a card as it is produced. Once the
+  run finishes, the same card is persisted inside the assistant reply and
+  reaches you again as an element on the `AIAssistantMessage` (see [Inline Cards
+  in AI Agent Replies](#inline-cards-in-ai-agent-replies)). Correlate them by
+  `cardId` to avoid rendering the card twice.
+</Note>
+
+---
+
+## Removing Listeners
+
+Always remove listeners when they are no longer needed (for example, on component unmount or page navigation) to prevent memory leaks and duplicate handling.
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+CometChat.removeMessageListener("UNIQUE_LISTENER_ID");
+CometChat.removeAIAssistantListener("UNIQUE_LISTENER_ID");
+```
+
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+CometChat.removeMessageListener("UNIQUE_LISTENER_ID");
+CometChat.removeAIAssistantListener("UNIQUE_LISTENER_ID");
+```
+
+</Tab>
+</Tabs>
+
+---
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Receive a Message" icon="inbox" href="/sdk/javascript/receive-message">
+    Handle real-time, unread, and historical messages of every type
+  </Card>
+  <Card title="AI Agents" icon="robot" href="/sdk/javascript/ai-agents">
+    Handle AI Agent runs, streaming events, and persisted agent replies
+  </Card>
+  <Card title="Real-Time Listeners" icon="tower-broadcast" href="/sdk/javascript/all-real-time-listeners">
+    See every callback on the MessageListener and AIAssistantListener
+  </Card>
+  <Card title="Message Reference" icon="book" href="/sdk/reference/messages">
+    Full class reference for CardMessage, AIAssistantElement, and card events
+  </Card>
+</CardGroup>

--- a/sdk/javascript/card-messages.mdx
+++ b/sdk/javascript/card-messages.mdx
@@ -13,9 +13,8 @@ The body of a card is **Card Schema JSON** — the same structured layout used b
   responsibility: pass that JSON to the **CometChat Cards** renderer for your
   framework.
 
-  - **React** — [`@cometchat/cards-react`](https://www.npmjs.com/package/@cometchat/cards-react) (`CometChatCardView`): see [Card Messages](/ui-kit/react/v6/card-messages#the-render-only-contract).
-  - **Angular** — [`@cometchat/cards-angular`](https://www.npmjs.com/package/@cometchat/cards-angular) (`CometChatCardView`): see [Card Messages](/ui-kit/angular/guides/card-messages#the-render-only-contract).
-  - **Vanilla / any framework** — [`@cometchat/cards`](https://www.npmjs.com/package/@cometchat/cards).
+  - **React** — please refer to the [Card Messages](/ui-kit/react/v6/card-messages#the-render-only-contract) guide.
+  - **Angular** — please refer to the [Card Messages](/ui-kit/angular/guides/card-messages#the-render-only-contract) guide.
 </Note>
 
 ## How Cards Arrive

--- a/sdk/javascript/message-structure-and-hierarchy.mdx
+++ b/sdk/javascript/message-structure-and-hierarchy.mdx
@@ -18,6 +18,7 @@ The below diagram helps you better understand the various message categories and
 | `custom`  | Developer-defined                         | Custom data (location, polls, etc.) |
 | `action`  | `groupMember`, `message`                  | System-generated events             |
 | `call`    | `audio`, `video`                          | Call-related messages               |
+| `card`    | `text`                                    | Rich [card messages](/sdk/javascript/card-messages) (receive-only) |
 
 ## Checking Message Category and Type
 

--- a/sdk/javascript/send-message.mdx
+++ b/sdk/javascript/send-message.mdx
@@ -932,6 +932,22 @@ The `sendCustomMessage()` method returns a [`CustomMessage`](/sdk/reference/mess
 
 ---
 
+## Card Message
+
+A [`CardMessage`](/sdk/reference/messages#cardmessage) (category `card`) is a rich, structured card rendered from Card Schema JSON.
+
+<Note>
+  **Card messages cannot be sent through the SDK.** `CardMessage` is
+  **receive-only** — there is no `sendCardMessage()` method. Cards are created
+  server-side via the [Platform (REST) API](/rest-api/messages/send-message) or
+  the **Dashboard Bubble Builder**, and delivered to clients through the
+  `onCardMessageReceived` callback of the `MessageListener`.
+</Note>
+
+To receive and render cards, see the [Card Messages guide](/sdk/javascript/card-messages).
+
+---
+
 ## Next Steps
 
 <CardGroup cols={2}>

--- a/sdk/reference/messages.mdx
+++ b/sdk/reference/messages.mdx
@@ -236,9 +236,10 @@ It inherits all properties from `BaseMessage` and adds the following.
 
 | Property | Getter | Return Type | Description |
 |----------|--------|-------------|-------------|
-| card | `getCard()` | `Object` \| `undefined` | The raw card JSON object (`data.card`); `undefined` when absent |
-| text | `getText()` | `string` | The plain-text content accompanying the card (`data.text`) |
+| card | `getCard()` | `Object` \| `undefined` | The raw Card Schema JSON object (`data.card`); `undefined` when absent |
+| text | `getText()` | `string` | The plain-text content accompanying the card (`data.text`); used as preview text |
 | fallbackText | `getFallbackText()` | `string` | Text to display when the card cannot be rendered (`card.fallbackText`) |
+| tags | `getTags()` | `string[]` | Tags associated with the message |
 
 ---
 

--- a/sdk/reference/messages.mdx
+++ b/sdk/reference/messages.mdx
@@ -15,6 +15,7 @@ BaseMessage
 ├── TextMessage
 ├── MediaMessage
 ├── CustomMessage
+├── CardMessage
 └── Action
 ```
 
@@ -202,6 +203,7 @@ It inherits all properties from `BaseMessage` and adds the following.
 | Property | Getter | Return Type | Description |
 |----------|--------|-------------|-------------|
 | assistantMessageData | `getAssistantMessageData()` | `AIAssistantMessageData` | The assistant message data containing runId, threadId, and text |
+| elements | `getElements()` | `AIAssistantElement[]` | Ordered content blocks of the reply (text, cards, etc.). Empty array when absent |
 
 ### AIAssistantMessageData
 
@@ -210,6 +212,33 @@ It inherits all properties from `BaseMessage` and adds the following.
 | runId | `getRunId()` | `string` | The run ID of the agent execution |
 | threadId | `getThreadId()` | `string` | The thread ID of the conversation |
 | text | `getText()` | `string` | The full text of the assistant's reply |
+
+---
+
+## AIAssistantElement
+
+`AIAssistantElement` is a single ordered content block returned by `AIAssistantMessage.getElements()`. Each element is a `{ type, value }` envelope; the SDK returns the `value` raw and never interprets it — branch on `getType()` to decide how to read `getData()`.
+
+| Property | Getter | Return Type | Description |
+|----------|--------|-------------|-------------|
+| type | `getType()` | `string` | The element type — `"text"`, `"card"`, or another platform-defined type |
+| data | `getData()` | `any` | The element's raw body. For `"text"` it is a string; for `"card"` it is `{ card, cardId }` |
+
+---
+
+## CardMessage
+
+`CardMessage` extends [BaseMessage](#basemessage) and represents a standalone card message (category `card`). It is received via the `onCardMessageReceived` callback of the [MessageListener](/sdk/javascript/all-real-time-listeners#message-listener). The SDK returns the card payload raw; your app renders it. See the [Card Messages guide](/sdk/javascript/card-messages).
+
+It inherits all properties from `BaseMessage` and adds the following.
+
+### Properties
+
+| Property | Getter | Return Type | Description |
+|----------|--------|-------------|-------------|
+| card | `getCard()` | `Object` \| `undefined` | The raw card JSON object (`data.card`); `undefined` when absent |
+| text | `getText()` | `string` | The plain-text content accompanying the card (`data.text`) |
+| fallbackText | `getFallbackText()` | `string` | Text to display when the card cannot be rendered (`card.fallbackText`) |
 
 ---
 
@@ -293,3 +322,50 @@ The `type` field identifies the specific event (e.g., `"run_started"`, `"tool_ca
 | data.timestamp | `getTimestamp()` | `number` | Timestamp of the event |
 | data.runId | `getRunId()` | `string` | The run ID of the agent execution |
 | data.threadId | `getThreadId()` | `string` | The thread ID of the conversation |
+
+---
+
+## AIAssistantCardStartedEvent
+
+`AIAssistantCardStartedEvent` extends [AIAssistantBaseEvent](#aiassistantbaseevent) and is emitted (event type `card_start`) when an AI Agent begins generating a card during a streaming run. See the [Card Messages guide](/sdk/javascript/card-messages#real-time-card-streaming-events).
+
+It inherits all properties from `AIAssistantBaseEvent` and adds the following.
+
+### Properties
+
+| Property | Getter | Return Type | Description |
+|----------|--------|-------------|-------------|
+| streamMessageId | `getStreamMessageId()` | `string` | ID correlating the stream events for this card |
+| cardId | `getCardId()` | `string` | ID of the card being generated |
+| executionText | `getExecutionText()` | `string` | Text shown while the card is being generated |
+
+---
+
+## AIAssistantCardReceivedEvent
+
+`AIAssistantCardReceivedEvent` extends [AIAssistantBaseEvent](#aiassistantbaseevent) and is emitted (event type `card`) when the full card payload is delivered during a streaming run.
+
+It inherits all properties from `AIAssistantBaseEvent` and adds the following.
+
+### Properties
+
+| Property | Getter | Return Type | Description |
+|----------|--------|-------------|-------------|
+| streamMessageId | `getStreamMessageId()` | `string` | ID correlating the stream events for this card |
+| cardId | `getCardId()` | `string` | ID of the card |
+| card | `getCard()` | `any` | The raw card payload to render; `undefined` when absent |
+
+---
+
+## AIAssistantCardEndedEvent
+
+`AIAssistantCardEndedEvent` extends [AIAssistantBaseEvent](#aiassistantbaseevent) and is emitted (event type `card_end`) when card generation finishes during a streaming run.
+
+It inherits all properties from `AIAssistantBaseEvent` and adds the following.
+
+### Properties
+
+| Property | Getter | Return Type | Description |
+|----------|--------|-------------|-------------|
+| streamMessageId | `getStreamMessageId()` | `string` | ID correlating the stream events for this card |
+| cardId | `getCardId()` | `string` | ID of the card that finished generating |


### PR DESCRIPTION
Add a dedicated JavaScript SDK "Card Messages" page covering the three receive-only card mechanisms: standalone CardMessage (onCardMessageReceived), inline cards on AIAssistantMessage via getElements()/AIAssistantElement, and real-time card streaming events (card_start/card/card_end) on the AIAssistantListener.

- Add sdk/javascript/card-messages.mdx with TS + JS receive/render examples
- Add reference entries for CardMessage, AIAssistantElement, the elements accessor on AIAssistantMessage, and the three card events (messages.mdx)
- Add onCardMessageReceived + card-events note to all-real-time-listeners.mdx
- Add the card category to message-structure-and-hierarchy.mdx
- Cross-link card handling from ai-agents.mdx
- Register the new page in the Messaging nav group (docs.json)

## Description

<!-- Please include a summary of the changes and relevant context. -->

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [ ] Documentation correction/update
- [ ] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [ ] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [ ] My changes follow the documentation style guide
- [ ] I have checked for spelling and grammar errors
- [ ] All links in my changes are valid and working
- [ ] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
