### PR TITLE
docs(ui-kit): add AI agent 1:1 and group conversation note to AI assistant chat

### DIFF
--- a/ui-kit/react/components/ai-assistant-chat.mdx
+++ b/ui-kit/react/components/ai-assistant-chat.mdx
@@ -92,6 +92,11 @@ description: "AI agent chat interface with streaming responses, suggested messag
 ## Overview
 
 `CometChatAIAssistantChat` is an AI agent chat interface. It renders a full chat experience with streaming responses, suggested message pills, tool calling support, and a conversation history sidebar. Pass a `CometChat.User` representing the AI assistant and the component handles the rest — message threading, streaming display, and composer integration.
+
+<Note>
+**1:1 and group conversations.** AI Agents work in both one-on-one and group conversations. In a 1:1 chat, the end user talks directly with the agent user. In a group, the agent participates as a member — its messages (including cards) are delivered and attributed like any other member's message. If the group contains only one user and one agent, the agent responds automatically. In groups with more than two members, the agent only responds when @mentioned.
+</Note>
+
 <Info>
 **Live Preview** — interact with the default AI assistant chat.
 


### PR DESCRIPTION
## Description

Adds a clarifying note to the React v7 UI Kit `CometChatAIAssistantChat` documentation explaining that AI Agents work in both one-on-one and group conversations. The note describes how the agent participates as a group member (its messages, including cards, are delivered and attributed like any other member's), that it responds automatically in a single-user group, and that in groups with more than two members it only responds when @mentioned.

## Related Issue(s)

ENG-36071

## Type of Change

- [x] Documentation correction/update
- [ ] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

Scoped to `ui-kit/react/components/ai-assistant-chat.mdx`.

## Screenshots (if applicable)

N/A
