### PR TITLE
docs(js-sdk): add Upload Files documentation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3195,6 +3195,7 @@
                             "group": "Messaging",
                             "pages": [
                               "sdk/javascript/send-message",
+                              "sdk/javascript/upload-files",
                               "sdk/javascript/receive-message",
                               "sdk/javascript/card-messages",
                               "sdk/javascript/message-filtering",

--- a/sdk/javascript/error-codes.mdx
+++ b/sdk/javascript/error-codes.mdx
@@ -21,7 +21,7 @@ try {
 }
 ```
 
-**Error categories:** Initialization, Login, Calling, Messages, Groups, Users, Conversations, Receipts, AI, Extensions
+**Error categories:** Initialization, Login, Calling, Messages, Media Upload, Groups, Users, Conversations, Receipts, AI, Extensions
 </Accordion>
 
 Every error thrown by the CometChat SDK is a [`CometChatException`](/sdk/reference/auxiliary#cometchatexception) object with four properties:
@@ -112,6 +112,20 @@ try {
 | `REQUEST_IN_PROGRESS` | Request in progress. |
 | `NOT_ENOUGH_PARAMETERS` | Timestamp, MessageId, or updatedAfter is required to use fetchNext(). |
 | `INVALID_REASON_ID` | Invalid reasonId provided. |
+
+## Media Upload Errors
+
+Raised by the [Upload Files](/sdk/javascript/upload-files) flow — delivered through the `MediaUploadListener` (`onFileError` / `onFileFailure`) — and by `sendMediaMessage()`. **Rejected** errors (`onFileError`) mean the input must change and are not retryable; **failed** errors (`onFileFailure`) are transient and can be retried with `retryFileUpload()`.
+
+| Code | Surfaced via | Retryable | Message |
+|------|--------------|-----------|---------|
+| `ERR_INVALID_FILE_OBJECT` | `onFileError` | No | The provided file is invalid or its size cannot be determined. |
+| `ERR_FILE_SIZE_EXCEEDED` | `onFileError` | No | The file `%s` exceeds the maximum allowed size of `%s` bytes. |
+| `ERR_FILE_COUNT_EXCEEDED` | `sendMediaMessage()` | No | The number of attachments exceeds the allowed limit of `%s`. |
+| `ERR_S3_UPLOAD_FAILED` | `onFileFailure` | Yes | Failed to upload the file to storage. |
+| `ERR_PRESIGNED_URL_EXPIRED` | `onFileFailure` | Yes | The pre-signed upload URL has expired. Please retry the upload. |
+| `ERR_UPLOAD_STALLED` | `onFileFailure` | Yes | The upload stalled with no progress and was aborted. |
+| `ERR_UPLOAD_CANCELLED` | — | — | The upload was cancelled. |
 
 ## User Errors
 

--- a/sdk/javascript/error-codes.mdx
+++ b/sdk/javascript/error-codes.mdx
@@ -122,11 +122,11 @@ Raised by the [Upload Files](/sdk/javascript/upload-files) flow — delivered th
 | `ERR_INVALID_FILE_OBJECT` | `onFileError` | No | The provided file is invalid or its size cannot be determined. |
 | `ERR_FILE_SIZE_EXCEEDED` | `onFileError` | No | The file `%s` exceeds the maximum allowed size of `%s` bytes. |
 | `ERR_PERMISSION_DENIED` | `onFileError` | No | The sender does not have permission to upload media to the specified `receiverId` / `receiverType` (role/scope-based access control). |
+| `ERR_BAD_REQUEST` | `onFileError` | No | The server rejected the presign request for this file (e.g. a corrupted or otherwise invalid file). |
 | `ERR_FILE_COUNT_EXCEEDED` | `sendMediaMessage()` | No | The number of attachments exceeds the allowed limit of `%s`. |
 | `ERR_S3_UPLOAD_FAILED` | `onFileFailure`, `onFileError` | Yes / No | Failed to upload the file to storage (`onFileFailure`, retryable); also the fallback when the server declines a file with no specific code (`onFileError`, not retryable). |
 | `ERR_PRESIGNED_URL_EXPIRED` | `onFileFailure` | Yes | The pre-signed upload URL has expired. Please retry the upload. |
 | `ERR_UPLOAD_STALLED` | `onFileFailure` | Yes | The upload stalled with no progress and was aborted. |
-| `ERR_UPLOAD_CANCELLED` | — | — | The upload was cancelled. |
 
 ## User Errors
 

--- a/sdk/javascript/error-codes.mdx
+++ b/sdk/javascript/error-codes.mdx
@@ -115,7 +115,7 @@ try {
 
 ## Media Upload Errors
 
-Raised by the [Upload Files](/sdk/javascript/upload-files) flow — delivered through the `MediaUploadListener` (`onFileError` / `onFileFailure`) — and by `sendMediaMessage()`. **Rejected** errors (`onFileError`) mean the input must change and are not retryable; **failed** errors (`onFileFailure`) are transient and can be retried with `retryFileUpload()`.
+Raised by the [Upload Files](/sdk/javascript/upload-files) flow — delivered through the `UploadFileListener` (`onFileError` / `onFileFailure`) — and by `sendMediaMessage()`. **Rejected** errors (`onFileError`) mean the input must change and are not retryable; **failed** errors (`onFileFailure`) are transient and can be retried with `retryAttachment()`.
 
 | Code | Surfaced via | Retryable | Message |
 |------|--------------|-----------|---------|

--- a/sdk/javascript/error-codes.mdx
+++ b/sdk/javascript/error-codes.mdx
@@ -121,8 +121,9 @@ Raised by the [Upload Files](/sdk/javascript/upload-files) flow — delivered th
 |------|--------------|-----------|---------|
 | `ERR_INVALID_FILE_OBJECT` | `onFileError` | No | The provided file is invalid or its size cannot be determined. |
 | `ERR_FILE_SIZE_EXCEEDED` | `onFileError` | No | The file `%s` exceeds the maximum allowed size of `%s` bytes. |
+| `ERR_PERMISSION_DENIED` | `onFileError` | No | The sender does not have permission to upload media to the specified `receiverId` / `receiverType` (role/scope-based access control). |
 | `ERR_FILE_COUNT_EXCEEDED` | `sendMediaMessage()` | No | The number of attachments exceeds the allowed limit of `%s`. |
-| `ERR_S3_UPLOAD_FAILED` | `onFileFailure` | Yes | Failed to upload the file to storage. |
+| `ERR_S3_UPLOAD_FAILED` | `onFileFailure`, `onFileError` | Yes / No | Failed to upload the file to storage (`onFileFailure`, retryable); also the fallback when the server declines a file with no specific code (`onFileError`, not retryable). |
 | `ERR_PRESIGNED_URL_EXPIRED` | `onFileFailure` | Yes | The pre-signed upload URL has expired. Please retry the upload. |
 | `ERR_UPLOAD_STALLED` | `onFileFailure` | Yes | The upload stalled with no progress and was aborted. |
 | `ERR_UPLOAD_CANCELLED` | — | — | The upload was cancelled. |

--- a/sdk/javascript/send-message.mdx
+++ b/sdk/javascript/send-message.mdx
@@ -446,9 +446,15 @@ The `sendMediaMessage()` method returns a [`MediaMessage`](/sdk/reference/messag
 
 ## Multiple Attachments in a Media Message
 
-Starting version 3.0.9 & above the SDK supports sending multiple attachments in a single media message. As in the case of a single attachment in a media message, there are two ways you can send Media Messages using the CometChat SDK:
+The SDK supports sending multiple attachments in a single media message. A media message can carry up to a configurable maximum number of attachments (default **10**, controlled by the `file.count.max` app setting). `sendMediaMessage()` rejects with [`ERR_FILE_COUNT_EXCEEDED`](/sdk/javascript/error-codes#media-upload-errors) if you exceed it — read the current limit at runtime with `CometChat.getMaxAttachmentCount()`.
 
-1. **By providing an array of files:** You can now share an array of files while creating an object of the MediaMessage class. When the media message is sent using the `sendMediaMessage()` method, the files are uploaded to the CometChat servers & the URL of the files is sent in the success response of the `sendMediaMessage()` method.
+<Tip>
+**Recommended: upload first, then send.** For a real composer — where you want a progress bar per file, and the ability to cancel or retry individual files — upload the files with [`CometChat.uploadFiles()`](/sdk/javascript/upload-files), collect the resulting `Attachment`s, and attach them here with `setAttachments()`. This decouples the (slow, cancellable) upload from the (instant) send. See [Upload Files & Send Attachments](/sdk/javascript/upload-files) for the full flow.
+</Tip>
+
+There are two ways to send a multi-attachment media message using the CometChat SDK:
+
+1. **By providing an array of files:** You can share an array of files while creating an object of the MediaMessage class. When the media message is sent using the `sendMediaMessage()` method, the files are uploaded to the CometChat servers & the URL of the files is sent in the success response of the `sendMediaMessage()` method. This is the simplest path, but it gives no upload progress and no per-file cancel/retry — for that, [upload first](/sdk/javascript/upload-files).
 
 Getting files:
 
@@ -579,6 +585,8 @@ CometChat.sendMediaMessage(mediaMessage).then(
 </Tabs>
 
 ### Send Multiple URLs
+
+Provide an array of [`Attachment`](/sdk/reference/auxiliary#attachment) objects that already point at hosted URLs. This is also the path the [upload-then-send flow](/sdk/javascript/upload-files) uses — the `Attachment`s returned by `uploadFiles()` are ready to pass straight to `setAttachments()`.
 
 <Tabs>
 <Tab title="TypeScript (User)">

--- a/sdk/javascript/send-message.mdx
+++ b/sdk/javascript/send-message.mdx
@@ -449,7 +449,7 @@ The `sendMediaMessage()` method returns a [`MediaMessage`](/sdk/reference/messag
 The SDK supports sending multiple attachments in a single media message. A media message can carry up to a configurable maximum number of attachments (default **10**, controlled by the `file.count.max` app setting). `sendMediaMessage()` rejects with [`ERR_FILE_COUNT_EXCEEDED`](/sdk/javascript/error-codes#media-upload-errors) if you exceed it — read the current limit at runtime with `CometChat.getMaxAttachmentCount()`.
 
 <Tip>
-**Recommended: upload first, then send.** For a real composer — where you want a progress bar per file, and the ability to cancel or retry individual files — upload the files with [`CometChat.uploadFiles()`](/sdk/javascript/upload-files), collect the resulting `Attachment`s, and attach them here with `setAttachments()`. This decouples the (slow, cancellable) upload from the (instant) send. See [Upload Files & Send Attachments](/sdk/javascript/upload-files) for the full flow.
+**Recommended: upload first, then send.** For a real composer — where you want a progress bar per file, and the ability to remove or retry individual files — create an upload request with [`CometChat.createUploadFileRequest()`](/sdk/javascript/upload-files), upload your files through it, then collect the resulting `Attachment`s (`request.getAttachments()`) and attach them here with `setAttachments()`. This decouples the (slow, cancellable) upload from the (instant) send. See [Upload Files & Send Attachments](/sdk/javascript/upload-files) for the full flow.
 </Tip>
 
 There are two ways to send a multi-attachment media message using the CometChat SDK:
@@ -586,7 +586,7 @@ CometChat.sendMediaMessage(mediaMessage).then(
 
 ### Send Multiple URLs
 
-Provide an array of [`Attachment`](/sdk/reference/auxiliary#attachment) objects that already point at hosted URLs. This is also the path the [upload-then-send flow](/sdk/javascript/upload-files) uses — the `Attachment`s returned by `uploadFiles()` are ready to pass straight to `setAttachments()`.
+Provide an array of [`Attachment`](/sdk/reference/auxiliary#attachment) objects that already point at hosted URLs. This is also the path the [upload-then-send flow](/sdk/javascript/upload-files) uses — the `Attachment`s from an upload request's `getAttachments()` are ready to pass straight to `setAttachments()`.
 
 <Tabs>
 <Tab title="TypeScript (User)">

--- a/sdk/javascript/upload-files.mdx
+++ b/sdk/javascript/upload-files.mdx
@@ -21,7 +21,7 @@ The classic path (passing a file, or `FileList`, straight to the `MediaMessage` 
     Get platform-native file objects (e.g. `File`/`Blob` from an `<input type="file">` on web).
   </Step>
   <Step title="Upload">
-    Call `CometChat.uploadFiles(files, listener)`. It returns **synchronously** with a `batchId` and a `fileId` per file (in input order) so you can map callbacks back to your UI rows.
+    Call `CometChat.uploadFiles(files, receiverId, receiverType, listener)`. The **recipient** (`receiverId` + `receiverType`) is required — the server uses it to apply role- and scope-based access control before issuing upload URLs. It returns **synchronously** with a `batchId` and a `fileId` per file (in input order) so you can map callbacks back to your UI rows.
   </Step>
   <Step title="Track progress & handle failures">
     Your `MediaUploadListener` receives `onProgress` for each file, then `onFileUploaded` (success), `onFileError` (rejected — not retryable), or `onFileFailure` (failed — retryable). Use `cancelFileUpload()` / `retryFileUpload()` as the user acts.
@@ -48,6 +48,9 @@ The classic path (passing a file, or `FileList`, straight to the `MediaMessage` 
 ```typescript
 const files: FileList = (document.getElementById("files") as HTMLInputElement).files!;
 
+const receiverId = "UID";                              // recipient uid or guid
+const receiverType = CometChat.RECEIVER_TYPE.USER;     // "user" or "group"
+
 const listener = new CometChat.MediaUploadListener({
   onProgress: (fileId: string, loaded: number, total: number, percent: number) => {
     console.log(`${fileId}: ${percent}%`);
@@ -66,7 +69,12 @@ const listener = new CometChat.MediaUploadListener({
   },
 });
 
-const { batchId, fileIds } = CometChat.uploadFiles(Array.from(files), listener);
+const { batchId, fileIds } = CometChat.uploadFiles(
+  Array.from(files),
+  receiverId,
+  receiverType,
+  listener
+);
 console.log("Upload group:", batchId, fileIds);
 ```
 </Tab>
@@ -74,6 +82,9 @@ console.log("Upload group:", batchId, fileIds);
 <Tab title="JavaScript">
 ```javascript
 const files = document.getElementById("files").files;
+
+const receiverId = "UID";                              // recipient uid or guid
+const receiverType = CometChat.RECEIVER_TYPE.USER;     // "user" or "group"
 
 const listener = new CometChat.MediaUploadListener({
   onProgress: (fileId, loaded, total, percent) => {
@@ -93,7 +104,12 @@ const listener = new CometChat.MediaUploadListener({
   },
 });
 
-const { batchId, fileIds } = CometChat.uploadFiles(Array.from(files), listener);
+const { batchId, fileIds } = CometChat.uploadFiles(
+  Array.from(files),
+  receiverId,
+  receiverType,
+  listener
+);
 console.log("Upload group:", batchId, fileIds);
 ```
 </Tab>
@@ -101,11 +117,17 @@ console.log("Upload group:", batchId, fileIds);
 
 `uploadFiles()` accepts these arguments:
 
-| Parameter  | Type                                    | Description                                                                              | Required |
-| ---------- | --------------------------------------- | ---------------------------------------------------------------------------------------- | -------- |
-| `files`    | `Array<File \| Blob>`                    | Platform-native file objects to upload.                                                  | Yes      |
-| `listener` | `MediaUploadListener`                    | Callback bundle for progress, per-file outcomes, and batch completion.                   | Yes      |
-| `options`  | `UploadOptions`                          | Optional `{ concurrency?, batchId? }` — see [Upload options](#upload-options).            | No       |
+| Parameter      | Type                    | Description                                                                                                          | Required |
+| -------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
+| `files`        | `Array<File \| Blob>`   | Platform-native file objects to upload.                                                                             | Yes      |
+| `receiverId`   | `string`                | Intended recipient — a user's `uid` or a group's `guid`. The server needs it to authorize the upload (see below).   | Yes      |
+| `receiverType` | `string`                | `CometChat.RECEIVER_TYPE.USER` (`"user"`) or `CometChat.RECEIVER_TYPE.GROUP` (`"group"`).                            | Yes      |
+| `listener`     | `MediaUploadListener`   | Callback bundle for progress, per-file outcomes, and batch completion.                                             | Yes      |
+| `options`      | `UploadOptions`         | Optional `{ concurrency?, batchId? }` — see [Upload options](#upload-options).                                      | No       |
+
+<Warning>
+**The recipient must match the message you'll eventually send.** `receiverId` / `receiverType` are sent to the upload-authorization (presign) endpoint, which enforces the sender's **role- and scope-based access control** for that conversation *before* any bytes transfer. If the sender isn't allowed to send media to that user or group, each file is **rejected** via `onFileError` with `ERR_PERMISSION_DENIED` (not retryable). Pass the same recipient you'll set on the `MediaMessage` at send time — uploading against one recipient and sending to another can pass the upload check but is not the intended usage.
+</Warning>
 
 It returns **synchronously**:
 
@@ -131,7 +153,7 @@ Pass a `MediaUploadListener` with only the callbacks you need — all are option
 | `onComplete`     | `(result) => void`                                                | The batch drained (no files in flight). Delivers an aggregate [`UploadResult`](#uploadresult). |
 
 <Warning>
-**Rejected vs. failed — the key distinction.** `onFileError` (rejected) means the file itself is unacceptable — invalid file object, over the size limit, or the storage refused it. Retrying won't help; the user must swap the file. `onFileFailure` (failed) means a transient transport problem — network drop, an expired presigned URL, or a stalled upload. These **can** be retried with `retryFileUpload()`.
+**Rejected vs. failed — the key distinction.** `onFileError` (rejected) means the request itself is unacceptable — invalid file object, over the size limit, or the sender isn't permitted to upload to this recipient (`ERR_PERMISSION_DENIED`). Retrying won't help; the user must swap the file or you must fix the recipient/permissions. `onFileFailure` (failed) means a transient transport problem — network drop, an expired presigned URL, or a stalled upload. These **can** be retried with `retryFileUpload()`.
 </Warning>
 
 ### UploadResult
@@ -160,20 +182,20 @@ Pass an optional third argument to tune the batch:
 <Tab title="TypeScript">
 ```typescript
 // Upload 3 files at a time
-const { batchId } = CometChat.uploadFiles(firstFiles, listener, { concurrency: 3 });
+const { batchId } = CometChat.uploadFiles(firstFiles, receiverId, receiverType, listener, { concurrency: 3 });
 
-// Later, add more files to the same group
-CometChat.uploadFiles(moreFiles, listener, { batchId });
+// Later, add more files to the same group (same recipient)
+CometChat.uploadFiles(moreFiles, receiverId, receiverType, listener, { batchId });
 ```
 </Tab>
 
 <Tab title="JavaScript">
 ```javascript
 // Upload 3 files at a time
-const { batchId } = CometChat.uploadFiles(firstFiles, listener, { concurrency: 3 });
+const { batchId } = CometChat.uploadFiles(firstFiles, receiverId, receiverType, listener, { concurrency: 3 });
 
-// Later, add more files to the same group
-CometChat.uploadFiles(moreFiles, listener, { batchId });
+// Later, add more files to the same group (same recipient)
+CometChat.uploadFiles(moreFiles, receiverId, receiverType, listener, { batchId });
 ```
 </Tab>
 </Tabs>
@@ -231,22 +253,22 @@ Once your files are uploaded, collect their `Attachment`s (from `onFileUploaded`
 ```typescript
 const uploaded: CometChat.Attachment[] = [];
 
+// Declare the recipient once — used for BOTH the upload authorization and the message.
+const receiverID = "UID";
+const receiverType = CometChat.RECEIVER_TYPE.USER;
+
 const listener = new CometChat.MediaUploadListener({
   onProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
   onFileUploaded: (fileId, attachment) => uploaded.push(attachment),
   onFileFailure: (fileId, error) => markRetryable(fileId, error),
-  onFileError: (fileId, error) => markRejected(fileId, error),
+  onFileError: (fileId, error) => markRejected(fileId, error), // incl. ERR_PERMISSION_DENIED
   onComplete: async (result) => {
     if (result.successful.length === 0) return;
-
-    const receiverID = "UID";
-    const messageType = CometChat.MESSAGE_TYPE.FILE;
-    const receiverType = CometChat.RECEIVER_TYPE.USER;
 
     const mediaMessage = new CometChat.MediaMessage(
       receiverID,
       "",            // no raw file — attachments already carry hosted URLs
-      messageType,
+      CometChat.MESSAGE_TYPE.FILE,
       receiverType
     );
     mediaMessage.setAttachments(result.successful.map((s) => s.attachment));
@@ -262,7 +284,7 @@ const listener = new CometChat.MediaUploadListener({
 });
 
 const files = (document.getElementById("files") as HTMLInputElement).files!;
-CometChat.uploadFiles(Array.from(files), listener, { concurrency: 3 });
+CometChat.uploadFiles(Array.from(files), receiverID, receiverType, listener, { concurrency: 3 });
 ```
 </Tab>
 
@@ -270,22 +292,22 @@ CometChat.uploadFiles(Array.from(files), listener, { concurrency: 3 });
 ```javascript
 const uploaded = [];
 
+// Declare the recipient once — used for BOTH the upload authorization and the message.
+const receiverID = "UID";
+const receiverType = CometChat.RECEIVER_TYPE.USER;
+
 const listener = new CometChat.MediaUploadListener({
   onProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
   onFileUploaded: (fileId, attachment) => uploaded.push(attachment),
   onFileFailure: (fileId, error) => markRetryable(fileId, error),
-  onFileError: (fileId, error) => markRejected(fileId, error),
+  onFileError: (fileId, error) => markRejected(fileId, error), // incl. ERR_PERMISSION_DENIED
   onComplete: async (result) => {
     if (result.successful.length === 0) return;
-
-    const receiverID = "UID";
-    const messageType = CometChat.MESSAGE_TYPE.FILE;
-    const receiverType = CometChat.RECEIVER_TYPE.USER;
 
     const mediaMessage = new CometChat.MediaMessage(
       receiverID,
       "",            // no raw file — attachments already carry hosted URLs
-      messageType,
+      CometChat.MESSAGE_TYPE.FILE,
       receiverType
     );
     mediaMessage.setAttachments(result.successful.map((s) => s.attachment));
@@ -301,7 +323,7 @@ const listener = new CometChat.MediaUploadListener({
 });
 
 const files = document.getElementById("files").files;
-CometChat.uploadFiles(Array.from(files), listener, { concurrency: 3 });
+CometChat.uploadFiles(Array.from(files), receiverID, receiverType, listener, { concurrency: 3 });
 ```
 </Tab>
 </Tabs>
@@ -357,13 +379,14 @@ Every error delivered to `onFileError` / `onFileFailure` (and rejections from `s
 | -------------------------- | ------------------------- | --------- | ----------------------------------------------------------------- |
 | `ERR_INVALID_FILE_OBJECT`  | `onFileError`             | No        | The file is invalid or its size can't be determined.              |
 | `ERR_FILE_SIZE_EXCEEDED`   | `onFileError`             | No        | The file is larger than `file.size.max`.                          |
+| `ERR_PERMISSION_DENIED`    | `onFileError`             | No        | The sender isn't allowed to upload media to this `receiverId` / `receiverType` (role/scope access control). |
 | `ERR_FILE_COUNT_EXCEEDED`  | `sendMediaMessage()`      | No        | More attachments on the message than `file.count.max` allows.     |
-| `ERR_S3_UPLOAD_FAILED`     | `onFileFailure`           | Yes       | Storage rejected the upload, or the transport errored.            |
+| `ERR_S3_UPLOAD_FAILED`     | `onFileFailure`, `onFileError` | Yes / No | Storage rejected the upload or the transport errored (`onFileFailure`, retryable); also the fallback when the server declines a file with no specific code (`onFileError`, not retryable). |
 | `ERR_PRESIGNED_URL_EXPIRED`| `onFileFailure`           | Yes       | The pre-signed URL expired (a retry re-presigns automatically).   |
 | `ERR_UPLOAD_STALLED`       | `onFileFailure`           | Yes       | No progress for 30s; the upload was aborted.                      |
 | `ERR_UPLOAD_CANCELLED`     | —                         | —         | The upload was cancelled via `cancelFileUpload()`.                |
 
-See the full list on the [Error Codes](/sdk/javascript/error-codes#media-upload-errors) page.
+`ERR_PERMISSION_DENIED` is returned by the server's access-control check, so its exact code and message come from your backend. See the full list on the [Error Codes](/sdk/javascript/error-codes#media-upload-errors) page.
 
 ## Next Steps
 

--- a/sdk/javascript/upload-files.mdx
+++ b/sdk/javascript/upload-files.mdx
@@ -1,0 +1,383 @@
+---
+title: "Upload Files & Send Attachments"
+sidebarTitle: "Upload Files"
+description: "Upload files directly to storage with per-file progress, cancel, and retry — then send them as one or more media messages with multiple attachments."
+---
+
+`CometChat.uploadFiles()` uploads one or more files **directly to storage** and reports **per-file progress, success, and failure** through a listener. It is **decoupled from sending**: uploading returns you an [`Attachment`](/sdk/reference/auxiliary#attachment) (carrying a hosted `url`) for each file, which you then attach to a [`MediaMessage`](/sdk/reference/messages#mediamessage) and send with [`sendMediaMessage()`](/sdk/javascript/send-message#media-message).
+
+This is the recommended way to build a **multi-attachment composer**: upload a batch of files, show a progress bar per file, let the user cancel or retry individual files, and once they're ready, send them as a single media message with multiple attachments (or split across several messages).
+
+<Info>
+**Why upload separately instead of passing files to `sendMediaMessage()`?**
+
+The classic path (passing a file, or `FileList`, straight to the `MediaMessage` constructor) uploads and sends in one blocking call — you get no progress, no per-file cancel, and no per-file retry. `uploadFiles()` moves the upload out of the send call so you can drive a rich composer UI, then send instantly because the files are already hosted.
+</Info>
+
+## The upload-then-send flow
+
+<Steps>
+  <Step title="Collect files">
+    Get platform-native file objects (e.g. `File`/`Blob` from an `<input type="file">` on web).
+  </Step>
+  <Step title="Upload">
+    Call `CometChat.uploadFiles(files, listener)`. It returns **synchronously** with a `batchId` and a `fileId` per file (in input order) so you can map callbacks back to your UI rows.
+  </Step>
+  <Step title="Track progress & handle failures">
+    Your `MediaUploadListener` receives `onProgress` for each file, then `onFileUploaded` (success), `onFileError` (rejected — not retryable), or `onFileFailure` (failed — retryable). Use `cancelFileUpload()` / `retryFileUpload()` as the user acts.
+  </Step>
+  <Step title="Collect attachments">
+    Each `onFileUploaded` (and the final `onComplete`) hands you an `Attachment` with a hosted `url`. Gather the ones you want to send.
+  </Step>
+  <Step title="Build & send the message">
+    Put the attachments on a `MediaMessage` with `setAttachments([...])` and call `sendMediaMessage()`. Because the attachments already have URLs, the message is sent as JSON — no re-upload.
+  </Step>
+  <Step title="Clean up">
+    Call `clearUploadGroup(batchId)` after a successful send (or to abandon the composer) to release the batch from memory.
+  </Step>
+</Steps>
+
+## Upload files
+
+```html
+<input type="file" name="files" id="files" multiple />
+```
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+const files: FileList = (document.getElementById("files") as HTMLInputElement).files!;
+
+const listener = new CometChat.MediaUploadListener({
+  onProgress: (fileId: string, loaded: number, total: number, percent: number) => {
+    console.log(`${fileId}: ${percent}%`);
+  },
+  onFileUploaded: (fileId: string, attachment: CometChat.Attachment) => {
+    console.log(`${fileId} uploaded ->`, attachment.getUrl());
+  },
+  onFileError: (fileId: string, error: CometChat.CometChatException) => {
+    console.log(`${fileId} rejected (not retryable):`, error.code);
+  },
+  onFileFailure: (fileId: string, error: CometChat.CometChatException) => {
+    console.log(`${fileId} failed (retryable):`, error.code);
+  },
+  onComplete: (result: CometChat.UploadResult) => {
+    console.log("Batch settled:", result);
+  },
+});
+
+const { batchId, fileIds } = CometChat.uploadFiles(Array.from(files), listener);
+console.log("Upload group:", batchId, fileIds);
+```
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+const files = document.getElementById("files").files;
+
+const listener = new CometChat.MediaUploadListener({
+  onProgress: (fileId, loaded, total, percent) => {
+    console.log(`${fileId}: ${percent}%`);
+  },
+  onFileUploaded: (fileId, attachment) => {
+    console.log(`${fileId} uploaded ->`, attachment.getUrl());
+  },
+  onFileError: (fileId, error) => {
+    console.log(`${fileId} rejected (not retryable):`, error.code);
+  },
+  onFileFailure: (fileId, error) => {
+    console.log(`${fileId} failed (retryable):`, error.code);
+  },
+  onComplete: (result) => {
+    console.log("Batch settled:", result);
+  },
+});
+
+const { batchId, fileIds } = CometChat.uploadFiles(Array.from(files), listener);
+console.log("Upload group:", batchId, fileIds);
+```
+</Tab>
+</Tabs>
+
+`uploadFiles()` accepts these arguments:
+
+| Parameter  | Type                                    | Description                                                                              | Required |
+| ---------- | --------------------------------------- | ---------------------------------------------------------------------------------------- | -------- |
+| `files`    | `Array<File \| Blob>`                    | Platform-native file objects to upload.                                                  | Yes      |
+| `listener` | `MediaUploadListener`                    | Callback bundle for progress, per-file outcomes, and batch completion.                   | Yes      |
+| `options`  | `UploadOptions`                          | Optional `{ concurrency?, batchId? }` — see [Upload options](#upload-options).            | No       |
+
+It returns **synchronously**:
+
+| Field     | Type            | Description                                                                     |
+| --------- | --------------- | ------------------------------------------------------------------------------- |
+| `batchId` | `string`        | Identifier for this upload group. Use it with cancel / retry / clear methods.   |
+| `fileIds` | `Array<string>` | One id per input file, in the **same order** as `files`. Each id looks like `"<batchId>:<index>"`. |
+
+<Note>
+Validation, presigning, and the actual byte transfer all run **asynchronously** after the method returns. Use the `fileId`s to line each file up with its UI row, then update that row as the listener fires.
+</Note>
+
+## The MediaUploadListener
+
+Pass a `MediaUploadListener` with only the callbacks you need — all are optional. Unlike [`MessageListener`](/sdk/javascript/receive-message) or `CallListener`, it is **not** registered globally with a string id; it lives for the duration of the upload batch.
+
+| Callback         | Signature                                                          | Fires when                                                                        |
+| ---------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `onProgress`     | `(fileId, loaded, total, percent) => void`                        | Transfer progress for a file (throttled to ~1% increments).                       |
+| `onFileUploaded` | `(fileId, attachment) => void`                                    | A file finished uploading. `attachment` is a ready-to-send [`Attachment`](/sdk/reference/auxiliary#attachment). |
+| `onFileError`    | `(fileId, error) => void`                                         | A file was **rejected** — **not retryable** (fix the input or permissions).       |
+| `onFileFailure`  | `(fileId, error) => void`                                         | A file's transfer **failed** — **retryable** via `retryFileUpload()`.             |
+| `onComplete`     | `(result) => void`                                                | The batch drained (no files in flight). Delivers an aggregate [`UploadResult`](#uploadresult). |
+
+<Warning>
+**Rejected vs. failed — the key distinction.** `onFileError` (rejected) means the file itself is unacceptable — invalid file object, over the size limit, or the storage refused it. Retrying won't help; the user must swap the file. `onFileFailure` (failed) means a transient transport problem — network drop, an expired presigned URL, or a stalled upload. These **can** be retried with `retryFileUpload()`.
+</Warning>
+
+### UploadResult
+
+`onComplete` receives the group's settled state. `onComplete` fires **each time** the group drains — including after a retry adds new work and it drains again.
+
+```typescript
+interface UploadResult {
+  batchId: string;
+  successful: Array<{ fileId: string; attachment: Attachment }>; // uploaded, ready to send
+  rejected:   Array<{ fileId: string; error: CometChatException }>; // reported via onFileError — not retryable
+  failed:     Array<{ fileId: string; error: CometChatException }>; // reported via onFileFailure — retryable
+}
+```
+
+## Upload options
+
+Pass an optional third argument to tune the batch:
+
+| Option        | Type     | Default | Description                                                                                          |
+| ------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
+| `concurrency` | `number` | `1`     | How many files upload simultaneously. Defaults to sequential (`1`); raise it to upload in parallel.  |
+| `batchId`     | `string` | —       | Pass an **existing** group's `batchId` to add more files to it (incremental) instead of starting a new group. |
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+// Upload 3 files at a time
+const { batchId } = CometChat.uploadFiles(firstFiles, listener, { concurrency: 3 });
+
+// Later, add more files to the same group
+CometChat.uploadFiles(moreFiles, listener, { batchId });
+```
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+// Upload 3 files at a time
+const { batchId } = CometChat.uploadFiles(firstFiles, listener, { concurrency: 3 });
+
+// Later, add more files to the same group
+CometChat.uploadFiles(moreFiles, listener, { batchId });
+```
+</Tab>
+</Tabs>
+
+## Cancel, retry & clear
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+// Abort and remove a single in-flight file (no-op if already uploaded)
+CometChat.cancelFileUpload(batchId, fileId);
+
+// Re-upload a single FAILED file (re-presigns automatically if the URL expired).
+// No-op for rejected files — those aren't retryable.
+CometChat.retryFileUpload(batchId, fileId);
+
+// Release the whole group from memory, aborting anything still in flight.
+// Call this after a successful send, or to abandon the composer.
+CometChat.clearUploadGroup(batchId);
+```
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+// Abort and remove a single in-flight file (no-op if already uploaded)
+CometChat.cancelFileUpload(batchId, fileId);
+
+// Re-upload a single FAILED file (re-presigns automatically if the URL expired).
+// No-op for rejected files — those aren't retryable.
+CometChat.retryFileUpload(batchId, fileId);
+
+// Release the whole group from memory, aborting anything still in flight.
+// Call this after a successful send, or to abandon the composer.
+CometChat.clearUploadGroup(batchId);
+```
+</Tab>
+</Tabs>
+
+| Method                          | Behavior                                                                                                          |
+| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `cancelFileUpload(batchId, fileId)` | Aborts and removes one file from the group. No-op if that file has already finished uploading.                |
+| `retryFileUpload(batchId, fileId)`  | Re-queues one **failed** file, re-presigning first if the earlier upload URL expired. No-op for rejected files. |
+| `clearUploadGroup(batchId)`         | Aborts any in-flight uploads and drops the group from SDK memory.                                              |
+
+<Note>
+All active upload groups are also cleared automatically on [`CometChat.logout()`](/sdk/javascript/authentication-overview).
+</Note>
+
+## Send the uploaded files as a media message
+
+Once your files are uploaded, collect their `Attachment`s (from `onFileUploaded` or from `result.successful` in `onComplete`), set them on a `MediaMessage`, and send. One upload batch can go out as a single multi-attachment message, or you can split the attachments across several messages.
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+const uploaded: CometChat.Attachment[] = [];
+
+const listener = new CometChat.MediaUploadListener({
+  onProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
+  onFileUploaded: (fileId, attachment) => uploaded.push(attachment),
+  onFileFailure: (fileId, error) => markRetryable(fileId, error),
+  onFileError: (fileId, error) => markRejected(fileId, error),
+  onComplete: async (result) => {
+    if (result.successful.length === 0) return;
+
+    const receiverID = "UID";
+    const messageType = CometChat.MESSAGE_TYPE.FILE;
+    const receiverType = CometChat.RECEIVER_TYPE.USER;
+
+    const mediaMessage = new CometChat.MediaMessage(
+      receiverID,
+      "",            // no raw file — attachments already carry hosted URLs
+      messageType,
+      receiverType
+    );
+    mediaMessage.setAttachments(result.successful.map((s) => s.attachment));
+
+    try {
+      const sent = await CometChat.sendMediaMessage(mediaMessage);
+      console.log("Media message sent successfully", sent);
+      CometChat.clearUploadGroup(result.batchId);
+    } catch (error) {
+      console.log("Media message sending failed with error", error);
+    }
+  },
+});
+
+const files = (document.getElementById("files") as HTMLInputElement).files!;
+CometChat.uploadFiles(Array.from(files), listener, { concurrency: 3 });
+```
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+const uploaded = [];
+
+const listener = new CometChat.MediaUploadListener({
+  onProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
+  onFileUploaded: (fileId, attachment) => uploaded.push(attachment),
+  onFileFailure: (fileId, error) => markRetryable(fileId, error),
+  onFileError: (fileId, error) => markRejected(fileId, error),
+  onComplete: async (result) => {
+    if (result.successful.length === 0) return;
+
+    const receiverID = "UID";
+    const messageType = CometChat.MESSAGE_TYPE.FILE;
+    const receiverType = CometChat.RECEIVER_TYPE.USER;
+
+    const mediaMessage = new CometChat.MediaMessage(
+      receiverID,
+      "",            // no raw file — attachments already carry hosted URLs
+      messageType,
+      receiverType
+    );
+    mediaMessage.setAttachments(result.successful.map((s) => s.attachment));
+
+    try {
+      const sent = await CometChat.sendMediaMessage(mediaMessage);
+      console.log("Media message sent successfully", sent);
+      CometChat.clearUploadGroup(result.batchId);
+    } catch (error) {
+      console.log("Media message sending failed with error", error);
+    }
+  },
+});
+
+const files = document.getElementById("files").files;
+CometChat.uploadFiles(Array.from(files), listener, { concurrency: 3 });
+```
+</Tab>
+</Tabs>
+
+<Note>
+`sendMediaMessage()` enforces the **maximum attachments per message** (see [Limits](#limits)). If a batch has more successful uploads than the limit allows, split them across multiple `MediaMessage`s. See [Multiple Attachments in a Media Message](/sdk/javascript/send-message#multiple-attachments-in-a-media-message).
+</Note>
+
+## Limits
+
+Two independent checks guard the flow, each using a limit read from your app settings (with a built-in fallback):
+
+| Limit                    | Enforced in            | App setting      | Default    | On breach                                                              |
+| ------------------------ | ---------------------- | ---------------- | ---------- | --------------------------------------------------------------------- |
+| **Per-file size**        | `uploadFiles()`        | `file.size.max`  | 100 MB     | That file is rejected via `onFileError` with `ERR_FILE_SIZE_EXCEEDED`. |
+| **Attachments per message** | `sendMediaMessage()` | `file.count.max` | 10         | `sendMediaMessage()` rejects with `ERR_FILE_COUNT_EXCEEDED`.          |
+
+Read the current attachment-count limit at runtime with `getMaxAttachmentCount()` — useful for disabling the "add file" button in your composer once the user hits the cap:
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+const max: number = await CometChat.getMaxAttachmentCount();
+console.log("Max attachments per message:", max);
+```
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+const max = await CometChat.getMaxAttachmentCount();
+console.log("Max attachments per message:", max);
+```
+</Tab>
+</Tabs>
+
+<Note>
+The **per-file size** limit is checked in `uploadFiles()` (before the byte transfer), while the **attachment count** limit is checked in `sendMediaMessage()` (when you send). A batch can therefore succeed at upload time but still be rejected at send time if it exceeds the count limit — plan your composer around both.
+</Note>
+
+## Reliability behavior
+
+The SDK handles a few transport edge cases for you:
+
+- **Stalled uploads** — if a file makes no progress for 30 seconds, its upload is aborted and reported through `onFileFailure` with `ERR_UPLOAD_STALLED`. Retry it with `retryFileUpload()`.
+- **Expired upload URLs** — the pre-signed upload URL for each file is valid for 15 minutes. `retryFileUpload()` automatically requests a fresh URL if the original has expired, so retries keep working even after a long delay.
+- **Storage errors** — if storage rejects the upload, the failure surfaces through `onFileFailure` with `ERR_S3_UPLOAD_FAILED` and, where available, the storage's own message.
+
+## Error handling
+
+Every error delivered to `onFileError` / `onFileFailure` (and rejections from `sendMediaMessage()`) is a [`CometChatException`](/sdk/reference/auxiliary#cometchatexception). The upload-specific codes:
+
+| Code                       | Surfaced via              | Retryable | Meaning                                                            |
+| -------------------------- | ------------------------- | --------- | ----------------------------------------------------------------- |
+| `ERR_INVALID_FILE_OBJECT`  | `onFileError`             | No        | The file is invalid or its size can't be determined.              |
+| `ERR_FILE_SIZE_EXCEEDED`   | `onFileError`             | No        | The file is larger than `file.size.max`.                          |
+| `ERR_FILE_COUNT_EXCEEDED`  | `sendMediaMessage()`      | No        | More attachments on the message than `file.count.max` allows.     |
+| `ERR_S3_UPLOAD_FAILED`     | `onFileFailure`           | Yes       | Storage rejected the upload, or the transport errored.            |
+| `ERR_PRESIGNED_URL_EXPIRED`| `onFileFailure`           | Yes       | The pre-signed URL expired (a retry re-presigns automatically).   |
+| `ERR_UPLOAD_STALLED`       | `onFileFailure`           | Yes       | No progress for 30s; the upload was aborted.                      |
+| `ERR_UPLOAD_CANCELLED`     | —                         | —         | The upload was cancelled via `cancelFileUpload()`.                |
+
+See the full list on the [Error Codes](/sdk/javascript/error-codes#media-upload-errors) page.
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="Send A Message" icon="paper-plane" href="/sdk/javascript/send-message">
+    Send text, media, and custom messages
+  </Card>
+  <Card title="Multiple Attachments" icon="paperclip" href="/sdk/javascript/send-message#multiple-attachments-in-a-media-message">
+    Send several attachments in one media message
+  </Card>
+  <Card title="Error Codes" icon="triangle-exclamation" href="/sdk/javascript/error-codes#media-upload-errors">
+    Media upload error reference
+  </Card>
+  <Card title="Receive Messages" icon="inbox" href="/sdk/javascript/receive-message">
+    Listen for incoming messages in real-time
+  </Card>
+</CardGroup>

--- a/sdk/javascript/upload-files.mdx
+++ b/sdk/javascript/upload-files.mdx
@@ -327,7 +327,11 @@ All active upload batches are also cleared automatically on [`CometChat.logout()
 
 ## Send the uploaded files as a media message
 
-Once your files are uploaded, collect their `Attachment`s (from `request.getAttachments()` or from `result.successful` in `onComplete`), set them on a `MediaMessage`, and send. One batch can go out as a single multi-attachment message, or you can split the attachments across several messages — e.g. one message per media type using `getAttachmentsByType()`.
+Drive the send from an **explicit user action** (a "Send" button) — read the uploaded `Attachment`s from the request, build one or more `MediaMessage`s, and send. Splitting the batch into **one `MediaMessage` per media type** (via `getAttachmentsByType()`) keeps each message's type aligned with its content, so images arrive as image messages, files as file messages, and so on.
+
+<Warning>
+**Send from a button, not from `onComplete`.** `onComplete` fires **every time the batch drains** — including after a retry re-drains it. Sending there would ship whatever happened to be uploaded on that drain and (with `clearAll()`) discard the files the user was about to retry. Gate an explicit "Send" action on the batch being fully settled instead: at least one file, and every staged file uploaded (nothing pending, failed, or rejected).
+</Warning>
 
 <Tabs>
 <Tab title="TypeScript">
@@ -337,37 +341,47 @@ const receiverType = CometChat.RECEIVER_TYPE.USER;
 
 const request = CometChat.createUploadFileRequest(receiverID, receiverType).setConcurrency(3);
 
+// Track per-file outcomes to drive your composer UI — but never send from here.
 const listener = new CometChat.UploadFileListener({
   onFileProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
-  onFileFailure: (fileId, error) => markRetryable(fileId, error),
-  onFileError: (fileId, error) => markRejected(fileId, error), // incl. ERR_PERMISSION_DENIED
-  onComplete: async (result) => {
-    // Wait until nothing is in flight, then send what uploaded successfully.
-    if (request.getStatus() !== CometChat.UploadStatus.IDLE) return;
-    const attachments = request.getAttachments();
-    if (attachments.length === 0) return;
-
-    const mediaMessage = new CometChat.MediaMessage(
-      receiverID,
-      "",            // no raw file — attachments already carry hosted URLs
-      CometChat.MESSAGE_TYPE.FILE,
-      receiverType
-    );
-    mediaMessage.setAttachments(attachments);
-
-    try {
-      const sent = await CometChat.sendMediaMessage(mediaMessage);
-      console.log("Media message sent successfully", sent);
-      request.clearAll();
-    } catch (error) {
-      console.log("Media message sending failed with error", error);
-    }
-  },
+  onFileFailure: (fileId, error) => markRetryable(fileId, error), // request.retryAttachment(fileId)
+  onFileError: (fileId, error) => markRejected(fileId, error),    // not retryable — remove/replace the file
 });
 
 const files = (document.getElementById("files") as HTMLInputElement).files!;
 const items = Array.from(files).map((file) => ({ fileId: crypto.randomUUID(), file }));
 request.uploadAttachments(items, listener);
+
+// Enable your "Send" button only when every staged file has uploaded — i.e. nothing
+// pending, failed, or rejected. Have the user retry or remove the rest first.
+function canSend(): boolean {
+  const total = request.getAttachmentCount();
+  return total > 0 && request.getAttachments().length === total;
+}
+
+// Wire this to the "Send" button's click handler.
+async function send(): Promise<void> {
+  if (!canSend()) return;
+  try {
+    // One MediaMessage per media type, so each sends with the matching message type.
+    for (const type of ["image", "video", "audio", "file"] as const) {
+      const attachments = request.getAttachmentsByType(type);
+      if (attachments.length === 0) continue;
+
+      const mediaMessage = new CometChat.MediaMessage(
+        receiverID,
+        "",     // no raw file — attachments already carry hosted URLs
+        type,   // matches CometChat.MESSAGE_TYPE.IMAGE / VIDEO / AUDIO / FILE
+        receiverType
+      );
+      mediaMessage.setAttachments(attachments);
+      await CometChat.sendMediaMessage(mediaMessage);
+    }
+    request.clearAll(); // release the batch only after a successful send
+  } catch (error) {
+    console.log("Media message sending failed with error", error);
+  }
+}
 ```
 </Tab>
 
@@ -378,43 +392,53 @@ const receiverType = CometChat.RECEIVER_TYPE.USER;
 
 const request = CometChat.createUploadFileRequest(receiverID, receiverType).setConcurrency(3);
 
+// Track per-file outcomes to drive your composer UI — but never send from here.
 const listener = new CometChat.UploadFileListener({
   onFileProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
-  onFileFailure: (fileId, error) => markRetryable(fileId, error),
-  onFileError: (fileId, error) => markRejected(fileId, error), // incl. ERR_PERMISSION_DENIED
-  onComplete: async (result) => {
-    // Wait until nothing is in flight, then send what uploaded successfully.
-    if (request.getStatus() !== CometChat.UploadStatus.IDLE) return;
-    const attachments = request.getAttachments();
-    if (attachments.length === 0) return;
-
-    const mediaMessage = new CometChat.MediaMessage(
-      receiverID,
-      "",            // no raw file — attachments already carry hosted URLs
-      CometChat.MESSAGE_TYPE.FILE,
-      receiverType
-    );
-    mediaMessage.setAttachments(attachments);
-
-    try {
-      const sent = await CometChat.sendMediaMessage(mediaMessage);
-      console.log("Media message sent successfully", sent);
-      request.clearAll();
-    } catch (error) {
-      console.log("Media message sending failed with error", error);
-    }
-  },
+  onFileFailure: (fileId, error) => markRetryable(fileId, error), // request.retryAttachment(fileId)
+  onFileError: (fileId, error) => markRejected(fileId, error),    // not retryable — remove/replace the file
 });
 
 const files = document.getElementById("files").files;
 const items = Array.from(files).map((file) => ({ fileId: crypto.randomUUID(), file }));
 request.uploadAttachments(items, listener);
+
+// Enable your "Send" button only when every staged file has uploaded — i.e. nothing
+// pending, failed, or rejected. Have the user retry or remove the rest first.
+function canSend() {
+  const total = request.getAttachmentCount();
+  return total > 0 && request.getAttachments().length === total;
+}
+
+// Wire this to the "Send" button's click handler.
+async function send() {
+  if (!canSend()) return;
+  try {
+    // One MediaMessage per media type, so each sends with the matching message type.
+    for (const type of ["image", "video", "audio", "file"]) {
+      const attachments = request.getAttachmentsByType(type);
+      if (attachments.length === 0) continue;
+
+      const mediaMessage = new CometChat.MediaMessage(
+        receiverID,
+        "",     // no raw file — attachments already carry hosted URLs
+        type,   // matches CometChat.MESSAGE_TYPE.IMAGE / VIDEO / AUDIO / FILE
+        receiverType
+      );
+      mediaMessage.setAttachments(attachments);
+      await CometChat.sendMediaMessage(mediaMessage);
+    }
+    request.clearAll(); // release the batch only after a successful send
+  } catch (error) {
+    console.log("Media message sending failed with error", error);
+  }
+}
 ```
 </Tab>
 </Tabs>
 
 <Note>
-`sendMediaMessage()` enforces the **maximum attachments per message** (see [Limits](#limits)). If a batch has more successful uploads than the limit allows, split them across multiple `MediaMessage`s — grouping by kind with `getAttachmentsByType()` is a natural way to do this. See [Multiple Attachments in a Media Message](/sdk/javascript/send-message#multiple-attachments-in-a-media-message).
+`sendMediaMessage()` enforces the **maximum attachments per message** (see [Limits](#limits)). The per-type split above already keeps message types correct, but it does **not** guarantee each message is under the count limit — if a single type has more attachments than `file.count.max` allows, chunk that type across multiple `MediaMessage`s too. See [Multiple Attachments in a Media Message](/sdk/javascript/send-message#multiple-attachments-in-a-media-message).
 </Note>
 
 ## Limits

--- a/sdk/javascript/upload-files.mdx
+++ b/sdk/javascript/upload-files.mdx
@@ -1,43 +1,43 @@
 ---
 title: "Upload Files & Send Attachments"
 sidebarTitle: "Upload Files"
-description: "Upload files directly to storage with per-file progress, cancel, and retry — then send them as one or more media messages with multiple attachments."
+description: "Upload files directly to storage with per-file progress, remove, and retry through an UploadFileRequest — then send them as one or more media messages with multiple attachments."
 ---
 
-`CometChat.uploadFiles()` uploads one or more files **directly to storage** and reports **per-file progress, success, and failure** through a listener. It is **decoupled from sending**: uploading returns you an [`Attachment`](/sdk/reference/auxiliary#attachment) (carrying a hosted `url`) for each file, which you then attach to a [`MediaMessage`](/sdk/reference/messages#mediamessage) and send with [`sendMediaMessage()`](/sdk/javascript/send-message#media-message).
+`CometChat.createUploadFileRequest(receiverId, receiverType)` returns an **`UploadFileRequest`** — the entry point for uploading files **directly to storage** with **per-file progress, success, and failure**. Upload is **decoupled from sending**: each uploaded file yields an [`Attachment`](/sdk/reference/auxiliary#attachment) (carrying a hosted `url`), which you then attach to a [`MediaMessage`](/sdk/reference/messages#mediamessage) and send with [`sendMediaMessage()`](/sdk/javascript/send-message#media-message).
 
-This is the recommended way to build a **multi-attachment composer**: upload a batch of files, show a progress bar per file, let the user cancel or retry individual files, and once they're ready, send them as a single media message with multiple attachments (or split across several messages).
+A request object is scoped to **one destination** (`receiverId` / `receiverType`) and **one upload batch**. This is the recommended way to build a **multi-attachment composer**: create a request, upload a batch of files, show a progress bar per file, let the user remove or retry individual files, then send them as a single media message with multiple attachments (or split across several).
 
 <Info>
 **Why upload separately instead of passing files to `sendMediaMessage()`?**
 
-The classic path (passing a file, or `FileList`, straight to the `MediaMessage` constructor) uploads and sends in one blocking call — you get no progress, no per-file cancel, and no per-file retry. `uploadFiles()` moves the upload out of the send call so you can drive a rich composer UI, then send instantly because the files are already hosted.
+The classic path (passing a file, or `FileList`, straight to the `MediaMessage` constructor) uploads and sends in one blocking call — you get no progress, no per-file remove, and no per-file retry. An `UploadFileRequest` moves the upload out of the send call so you can drive a rich composer UI, then send instantly because the files are already hosted.
 </Info>
 
 ## The upload-then-send flow
 
 <Steps>
-  <Step title="Collect files">
-    Get platform-native file objects (e.g. `File`/`Blob` from an `<input type="file">` on web).
+  <Step title="Create a request">
+    Call `CometChat.createUploadFileRequest(receiverId, receiverType)`. The **recipient** is required — the server uses it to apply role- and scope-based access control before issuing upload URLs.
   </Step>
   <Step title="Upload">
-    Call `CometChat.uploadFiles(files, receiverId, receiverType, listener)`. The **recipient** (`receiverId` + `receiverType`) is required — the server uses it to apply role- and scope-based access control before issuing upload URLs. It returns **synchronously** with a `batchId` and a `fileId` per file (in input order) so you can map callbacks back to your UI rows.
+    Call `request.uploadAttachments([{ fileId, file }], listener)`. Each file needs a **caller-supplied `fileId`** (required) that is echoed back on every event, so you can map callbacks to your UI rows. Validation, presigning, and the byte transfer run asynchronously and report through the listener.
   </Step>
   <Step title="Track progress & handle failures">
-    Your `MediaUploadListener` receives `onProgress` for each file, then `onFileUploaded` (success), `onFileError` (rejected — not retryable), or `onFileFailure` (failed — retryable). Use `cancelFileUpload()` / `retryFileUpload()` as the user acts.
+    Your `UploadFileListener` receives `onFileProgress` per file, then `onFileUploaded` (success), `onFileError` (rejected — not retryable), or `onFileFailure` (failed — retryable). Use `request.removeAttachment()` / `request.retryAttachment()` as the user acts.
   </Step>
   <Step title="Collect attachments">
-    Each `onFileUploaded` (and the final `onComplete`) hands you an `Attachment` with a hosted `url`. Gather the ones you want to send.
+    Each `onFileUploaded` hands you an `Attachment` with a hosted `url`. You can also read them from the request at any time with `request.getAttachments()` / `request.getAttachmentsByType()`.
   </Step>
   <Step title="Build & send the message">
     Put the attachments on a `MediaMessage` with `setAttachments([...])` and call `sendMediaMessage()`. Because the attachments already have URLs, the message is sent as JSON — no re-upload.
   </Step>
   <Step title="Clean up">
-    Call `clearUploadGroup(batchId)` after a successful send (or to abandon the composer) to release the batch from memory.
+    Call `request.clearAll()` after a successful send (or to abandon the composer) to release the batch from memory.
   </Step>
 </Steps>
 
-## Upload files
+## Create an upload request
 
 ```html
 <input type="file" name="files" id="files" multiple />
@@ -46,13 +46,51 @@ The classic path (passing a file, or `FileList`, straight to the `MediaMessage` 
 <Tabs>
 <Tab title="TypeScript">
 ```typescript
+const receiverID: string = "UID";
+const receiverType: string = CometChat.RECEIVER_TYPE.USER;
+
+const request: CometChat.UploadFileRequest = CometChat.createUploadFileRequest(
+  receiverID,
+  receiverType
+);
+```
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+const receiverID = "UID";
+const receiverType = CometChat.RECEIVER_TYPE.USER;
+
+const request = CometChat.createUploadFileRequest(receiverID, receiverType);
+```
+</Tab>
+</Tabs>
+
+`createUploadFileRequest()` accepts:
+
+| Parameter      | Type     | Description                                                          | Required |
+| -------------- | -------- | ------------------------------------------------------------------- | -------- |
+| `receiverId`   | `string` | UID of the user or GUID of the group the files will be sent to.     | Yes      |
+| `receiverType` | `string` | `CometChat.RECEIVER_TYPE.USER` or `CometChat.RECEIVER_TYPE.GROUP`.   | Yes      |
+
+<Warning>
+**The recipient must match the message you'll eventually send.** `receiverId` / `receiverType` are sent to the upload-authorization (presign) endpoint, which enforces the sender's **role- and scope-based access control** for that conversation *before* any bytes transfer. If the sender isn't allowed to send media to that user or group, each file is **rejected** via `onFileError` with `ERR_PERMISSION_DENIED` (not retryable). Pass the same recipient you'll set on the `MediaMessage` at send time.
+</Warning>
+
+## Upload files
+
+Build an `UploadFileListener` and call `uploadAttachments()` (or `uploadAttachment()` for a single file). Each item pairs a file with a **required, caller-supplied `fileId`**.
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
 const files: FileList = (document.getElementById("files") as HTMLInputElement).files!;
 
-const receiverId = "UID";                              // recipient uid or guid
-const receiverType = CometChat.RECEIVER_TYPE.USER;     // "user" or "group"
+// Pair each file with an id you own, so you can map events back to your UI.
+const items = Array.from(files).map((file) => ({ fileId: crypto.randomUUID(), file }));
 
-const listener = new CometChat.MediaUploadListener({
-  onProgress: (fileId: string, loaded: number, total: number, percent: number) => {
+const listener = new CometChat.UploadFileListener({
+  onFileProgress: (fileId: string, loaded: number, total: number, percent: number) => {
     console.log(`${fileId}: ${percent}%`);
   },
   onFileUploaded: (fileId: string, attachment: CometChat.Attachment) => {
@@ -69,13 +107,7 @@ const listener = new CometChat.MediaUploadListener({
   },
 });
 
-const { batchId, fileIds } = CometChat.uploadFiles(
-  Array.from(files),
-  receiverId,
-  receiverType,
-  listener
-);
-console.log("Upload group:", batchId, fileIds);
+request.uploadAttachments(items, listener);
 ```
 </Tab>
 
@@ -83,11 +115,11 @@ console.log("Upload group:", batchId, fileIds);
 ```javascript
 const files = document.getElementById("files").files;
 
-const receiverId = "UID";                              // recipient uid or guid
-const receiverType = CometChat.RECEIVER_TYPE.USER;     // "user" or "group"
+// Pair each file with an id you own, so you can map events back to your UI.
+const items = Array.from(files).map((file) => ({ fileId: crypto.randomUUID(), file }));
 
-const listener = new CometChat.MediaUploadListener({
-  onProgress: (fileId, loaded, total, percent) => {
+const listener = new CometChat.UploadFileListener({
+  onFileProgress: (fileId, loaded, total, percent) => {
     console.log(`${fileId}: ${percent}%`);
   },
   onFileUploaded: (fileId, attachment) => {
@@ -104,61 +136,41 @@ const listener = new CometChat.MediaUploadListener({
   },
 });
 
-const { batchId, fileIds } = CometChat.uploadFiles(
-  Array.from(files),
-  receiverId,
-  receiverType,
-  listener
-);
-console.log("Upload group:", batchId, fileIds);
+request.uploadAttachments(items, listener);
 ```
 </Tab>
 </Tabs>
 
-`uploadFiles()` accepts these arguments:
-
-| Parameter      | Type                    | Description                                                                                                          | Required |
-| -------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------- | -------- |
-| `files`        | `Array<File \| Blob>`   | Platform-native file objects to upload.                                                                             | Yes      |
-| `receiverId`   | `string`                | Intended recipient — a user's `uid` or a group's `guid`. The server needs it to authorize the upload (see below).   | Yes      |
-| `receiverType` | `string`                | `CometChat.RECEIVER_TYPE.USER` (`"user"`) or `CometChat.RECEIVER_TYPE.GROUP` (`"group"`).                            | Yes      |
-| `listener`     | `MediaUploadListener`   | Callback bundle for progress, per-file outcomes, and batch completion.                                             | Yes      |
-| `options`      | `UploadOptions`         | Optional `{ concurrency?, batchId? }` — see [Upload options](#upload-options).                                      | No       |
-
-<Warning>
-**The recipient must match the message you'll eventually send.** `receiverId` / `receiverType` are sent to the upload-authorization (presign) endpoint, which enforces the sender's **role- and scope-based access control** for that conversation *before* any bytes transfer. If the sender isn't allowed to send media to that user or group, each file is **rejected** via `onFileError` with `ERR_PERMISSION_DENIED` (not retryable). Pass the same recipient you'll set on the `MediaMessage` at send time — uploading against one recipient and sending to another can pass the upload check but is not the intended usage.
-</Warning>
-
-It returns **synchronously**:
-
-| Field     | Type            | Description                                                                     |
-| --------- | --------------- | ------------------------------------------------------------------------------- |
-| `batchId` | `string`        | Identifier for this upload group. Use it with cancel / retry / clear methods.   |
-| `fileIds` | `Array<string>` | One id per input file, in the **same order** as `files`. Each id looks like `"<batchId>:<index>"`. |
+| Method                                        | Description                                                                                          |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `uploadAttachments(items, listener?)`         | Upload multiple files. `items` is `{ fileId, file }[]`. `listener` receives events for these files. |
+| `uploadAttachment(fileId, file, listener?)`   | Upload a single file under `fileId`.                                                                 |
 
 <Note>
-Validation, presigning, and the actual byte transfer all run **asynchronously** after the method returns. Use the `fileId`s to line each file up with its UI row, then update that row as the listener fires.
+**`fileId` is caller-supplied and required.** The SDK does not generate one — you provide a stable id per file (echoed back unchanged on every event) so you can line each file up with its UI row. A `fileId` already present in the batch is **silently skipped** (deduped), so re-adding the same file is a no-op. `file` must be a platform-native `File`/`Blob` (the pipeline needs a numeric `size`).
+
+Validation, presigning, and the byte transfer all run **asynchronously** after `uploadAttachments()` returns — track outcomes through the listener.
 </Note>
 
-## The MediaUploadListener
+## The UploadFileListener
 
-Pass a `MediaUploadListener` with only the callbacks you need — all are optional. Unlike [`MessageListener`](/sdk/javascript/receive-message) or `CallListener`, it is **not** registered globally with a string id; it lives for the duration of the upload batch.
+Pass an `UploadFileListener` with only the callbacks you need — all are optional. Unlike [`MessageListener`](/sdk/javascript/receive-message) or `CallListener`, it is **not** registered globally with a string id; it lives for the duration of the upload batch.
 
 | Callback         | Signature                                                          | Fires when                                                                        |
 | ---------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| `onProgress`     | `(fileId, loaded, total, percent) => void`                        | Transfer progress for a file (throttled to ~1% increments).                       |
+| `onFileProgress` | `(fileId, loaded, total, percent) => void`                        | Transfer progress for a file (throttled to ~1% increments).                       |
 | `onFileUploaded` | `(fileId, attachment) => void`                                    | A file finished uploading. `attachment` is a ready-to-send [`Attachment`](/sdk/reference/auxiliary#attachment). |
 | `onFileError`    | `(fileId, error) => void`                                         | A file was **rejected** — **not retryable** (fix the input or permissions).       |
-| `onFileFailure`  | `(fileId, error) => void`                                         | A file's transfer **failed** — **retryable** via `retryFileUpload()`.             |
+| `onFileFailure`  | `(fileId, error) => void`                                         | A file's transfer **failed** — **retryable** via `retryAttachment()`.             |
 | `onComplete`     | `(result) => void`                                                | The batch drained (no files in flight). Delivers an aggregate [`UploadResult`](#uploadresult). |
 
 <Warning>
-**Rejected vs. failed — the key distinction.** `onFileError` (rejected) means the request itself is unacceptable — invalid file object, over the size limit, or the sender isn't permitted to upload to this recipient (`ERR_PERMISSION_DENIED`). Retrying won't help; the user must swap the file or you must fix the recipient/permissions. `onFileFailure` (failed) means a transient transport problem — network drop, an expired presigned URL, or a stalled upload. These **can** be retried with `retryFileUpload()`.
+**Rejected vs. failed — the key distinction.** `onFileError` (rejected) means the request itself is unacceptable — invalid file object, over the size limit, or the sender isn't permitted to upload to this recipient (`ERR_PERMISSION_DENIED`). Retrying won't help; the user must swap the file or you must fix the recipient/permissions. `onFileFailure` (failed) means a transient transport problem — network drop, an expired presigned URL, or a stalled upload. These **can** be retried with `retryAttachment()`.
 </Warning>
 
 ### UploadResult
 
-`onComplete` receives the group's settled state. `onComplete` fires **each time** the group drains — including after a retry adds new work and it drains again.
+`onComplete` receives the batch's settled state. It fires **each time** the batch drains — including after a retry adds new work and it drains again.
 
 ```typescript
 interface UploadResult {
@@ -169,101 +181,171 @@ interface UploadResult {
 }
 ```
 
-## Upload options
+## Configuring the request
 
-Pass an optional third argument to tune the batch:
-
-| Option        | Type     | Default | Description                                                                                          |
-| ------------- | -------- | ------- | ---------------------------------------------------------------------------------------------------- |
-| `concurrency` | `number` | `1`     | How many files upload simultaneously. Defaults to sequential (`1`); raise it to upload in parallel.  |
-| `batchId`     | `string` | —       | Pass an **existing** group's `batchId` to add more files to it (incremental) instead of starting a new group. |
+Chainable setters let you configure the batch before (or between) uploads:
 
 <Tabs>
 <Tab title="TypeScript">
 ```typescript
-// Upload 3 files at a time
-const { batchId } = CometChat.uploadFiles(firstFiles, receiverId, receiverType, listener, { concurrency: 3 });
+request
+  .setConcurrency(3)              // upload up to 3 files at once (default 1, sequential)
+  .setParentMessageId(parentId); // mark this batch as belonging to a thread
 
-// Later, add more files to the same group (same recipient)
-CometChat.uploadFiles(moreFiles, receiverId, receiverType, listener, { batchId });
+const batchId: string = request.getBatchId(); // auto-generated UUID unless you set one
 ```
 </Tab>
 
 <Tab title="JavaScript">
 ```javascript
-// Upload 3 files at a time
-const { batchId } = CometChat.uploadFiles(firstFiles, receiverId, receiverType, listener, { concurrency: 3 });
+request
+  .setConcurrency(3)              // upload up to 3 files at once (default 1, sequential)
+  .setParentMessageId(parentId); // mark this batch as belonging to a thread
 
-// Later, add more files to the same group (same recipient)
-CometChat.uploadFiles(moreFiles, receiverId, receiverType, listener, { batchId });
+const batchId = request.getBatchId(); // auto-generated UUID unless you set one
 ```
 </Tab>
 </Tabs>
 
-## Cancel, retry & clear
-
-<Tabs>
-<Tab title="TypeScript">
-```typescript
-// Abort and remove a single in-flight file (no-op if already uploaded)
-CometChat.cancelFileUpload(batchId, fileId);
-
-// Re-upload a single FAILED file (re-presigns automatically if the URL expired).
-// No-op for rejected files — those aren't retryable.
-CometChat.retryFileUpload(batchId, fileId);
-
-// Release the whole group from memory, aborting anything still in flight.
-// Call this after a successful send, or to abandon the composer.
-CometChat.clearUploadGroup(batchId);
-```
-</Tab>
-
-<Tab title="JavaScript">
-```javascript
-// Abort and remove a single in-flight file (no-op if already uploaded)
-CometChat.cancelFileUpload(batchId, fileId);
-
-// Re-upload a single FAILED file (re-presigns automatically if the URL expired).
-// No-op for rejected files — those aren't retryable.
-CometChat.retryFileUpload(batchId, fileId);
-
-// Release the whole group from memory, aborting anything still in flight.
-// Call this after a successful send, or to abandon the composer.
-CometChat.clearUploadGroup(batchId);
-```
-</Tab>
-</Tabs>
-
-| Method                          | Behavior                                                                                                          |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `cancelFileUpload(batchId, fileId)` | Aborts and removes one file from the group. No-op if that file has already finished uploading.                |
-| `retryFileUpload(batchId, fileId)`  | Re-queues one **failed** file, re-presigning first if the earlier upload URL expired. No-op for rejected files. |
-| `clearUploadGroup(batchId)`         | Aborts any in-flight uploads and drops the group from SDK memory.                                              |
+| Method                        | Description                                                                                                    |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `setConcurrency(count)`       | How many files upload simultaneously. Default `1` (sequential). Applies from the next drain onward.            |
+| `setBatchId(batchId)`         | Set the batch id all files share. Optional — the request auto-generates a UUID. **Locked once uploading starts.** |
+| `getBatchId()`                | The effective batch id (app-set or auto-generated).                                                            |
+| `setParentMessageId(id)`      | Mark the batch as belonging to a thread — sent to the presign endpoint. Omit for a top-level message.          |
 
 <Note>
-All active upload groups are also cleared automatically on [`CometChat.logout()`](/sdk/javascript/authentication-overview).
+Each request owns exactly one batch. For separate destinations (e.g. a main conversation and a thread), create a **separate `UploadFileRequest`** for each — their file ids never cross.
+</Note>
+
+### Adding more files to the batch
+
+To add files incrementally (e.g. the user picks more while earlier uploads are still running), just call `uploadAttachments()` again **on the same request** — they join the same batch. Re-adding a `fileId` already in the batch is skipped.
+
+## Per-call and global listeners
+
+There are two listener scopes, and events fire on **both**:
+
+- **Per-call listener** — the `listener` you pass to `uploadAttachment()` / `uploadAttachments()`. It receives events only for the files in *that* call.
+- **Global batch listener** — registered with `request.addUploadListener(listener)`. It receives events for **every** file across all upload calls on the request. There is a **single global slot**: a later `addUploadListener()` overrides the previous one; `removeUploadListener()` clears it.
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+// One listener for the whole batch, regardless of how many upload calls you make.
+request.addUploadListener(
+  new CometChat.UploadFileListener({
+    onFileProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
+    onFileUploaded: (fileId, attachment) => markUploaded(fileId, attachment),
+    onComplete: (result) => console.log("Whole batch settled:", result),
+  })
+);
+
+// Later:
+request.removeUploadListener();
+```
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+// One listener for the whole batch, regardless of how many upload calls you make.
+request.addUploadListener(
+  new CometChat.UploadFileListener({
+    onFileProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
+    onFileUploaded: (fileId, attachment) => markUploaded(fileId, attachment),
+    onComplete: (result) => console.log("Whole batch settled:", result),
+  })
+);
+
+// Later:
+request.removeUploadListener();
+```
+</Tab>
+</Tabs>
+
+## Reading the batch
+
+Query the request's current state at any time — useful when the user hits "send":
+
+| Method                       | Returns             | Notes                                                                                    |
+| ---------------------------- | ------------------- | ---------------------------------------------------------------------------------------- |
+| `getAttachment(fileId)`      | `Attachment \| null` | The uploaded attachment for `fileId`, or `null` if unknown or **not yet uploaded**.      |
+| `getAttachments()`           | `Attachment[]`      | All **uploaded** attachments in the batch.                                                |
+| `getAttachmentsByType(type)` | `Attachment[]`      | Uploaded attachments of one kind (`"image"` / `"video"` / `"audio"` / `"file"`) — always an array. |
+| `getAttachmentCount()`       | `number`            | Total files in the batch in **any** state (in-progress, failed, or uploaded).            |
+| `getStatus()`                | `UploadStatus`      | `IN_PROGRESS` while any file is still uploading, else `IDLE` (an empty batch is `IDLE`).  |
+
+<Note>
+The attachment getters (`getAttachment`, `getAttachments`, `getAttachmentsByType`) return **only uploaded** files, so they're safe to hand straight to `setAttachments()`. `getAttachmentCount()` counts every file regardless of state, so you can compare it against `getAttachments().length` to see how many are still pending.
+</Note>
+
+## Remove, retry & clear
+
+<Tabs>
+<Tab title="TypeScript">
+```typescript
+// Remove one file: aborts its in-flight upload (silently — no onFileFailure),
+// or drops it from the batch if it has already uploaded.
+request.removeAttachment(fileId);
+
+// Re-upload one FAILED file (re-presigns automatically if the URL expired).
+// No-op for rejected or already-uploaded files.
+request.retryAttachment(fileId);
+
+// Release the whole batch from memory, aborting anything still in flight.
+// Call this after a successful send, or to abandon the composer.
+request.clearAll();
+```
+</Tab>
+
+<Tab title="JavaScript">
+```javascript
+// Remove one file: aborts its in-flight upload (silently — no onFileFailure),
+// or drops it from the batch if it has already uploaded.
+request.removeAttachment(fileId);
+
+// Re-upload one FAILED file (re-presigns automatically if the URL expired).
+// No-op for rejected or already-uploaded files.
+request.retryAttachment(fileId);
+
+// Release the whole batch from memory, aborting anything still in flight.
+// Call this after a successful send, or to abandon the composer.
+request.clearAll();
+```
+</Tab>
+</Tabs>
+
+| Method                     | Behavior                                                                                                                    |
+| -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `removeAttachment(fileId)` | Removes one file from the batch. If it's still uploading, the transfer is aborted **silently** (no `onFileFailure`); if it already uploaded, it's dropped from the set. |
+| `retryAttachment(fileId)`  | Re-uploads one **failed** file, re-presigning first if the earlier upload URL expired. No-op for rejected or uploaded files. |
+| `clearAll()`               | Aborts any in-flight uploads and drops the whole batch from SDK memory.                                                     |
+
+<Note>
+All active upload batches are also cleared automatically on [`CometChat.logout()`](/sdk/javascript/authentication-overview). Since there is no send hook, call `clearAll()` yourself after a successful send so a batch doesn't linger in memory until logout.
 </Note>
 
 ## Send the uploaded files as a media message
 
-Once your files are uploaded, collect their `Attachment`s (from `onFileUploaded` or from `result.successful` in `onComplete`), set them on a `MediaMessage`, and send. One upload batch can go out as a single multi-attachment message, or you can split the attachments across several messages.
+Once your files are uploaded, collect their `Attachment`s (from `request.getAttachments()` or from `result.successful` in `onComplete`), set them on a `MediaMessage`, and send. One batch can go out as a single multi-attachment message, or you can split the attachments across several messages — e.g. one message per media type using `getAttachmentsByType()`.
 
 <Tabs>
 <Tab title="TypeScript">
 ```typescript
-const uploaded: CometChat.Attachment[] = [];
-
-// Declare the recipient once — used for BOTH the upload authorization and the message.
 const receiverID = "UID";
 const receiverType = CometChat.RECEIVER_TYPE.USER;
 
-const listener = new CometChat.MediaUploadListener({
-  onProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
-  onFileUploaded: (fileId, attachment) => uploaded.push(attachment),
+const request = CometChat.createUploadFileRequest(receiverID, receiverType).setConcurrency(3);
+
+const listener = new CometChat.UploadFileListener({
+  onFileProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
   onFileFailure: (fileId, error) => markRetryable(fileId, error),
   onFileError: (fileId, error) => markRejected(fileId, error), // incl. ERR_PERMISSION_DENIED
   onComplete: async (result) => {
-    if (result.successful.length === 0) return;
+    // Wait until nothing is in flight, then send what uploaded successfully.
+    if (request.getStatus() !== CometChat.UploadStatus.IDLE) return;
+    const attachments = request.getAttachments();
+    if (attachments.length === 0) return;
 
     const mediaMessage = new CometChat.MediaMessage(
       receiverID,
@@ -271,12 +353,12 @@ const listener = new CometChat.MediaUploadListener({
       CometChat.MESSAGE_TYPE.FILE,
       receiverType
     );
-    mediaMessage.setAttachments(result.successful.map((s) => s.attachment));
+    mediaMessage.setAttachments(attachments);
 
     try {
       const sent = await CometChat.sendMediaMessage(mediaMessage);
       console.log("Media message sent successfully", sent);
-      CometChat.clearUploadGroup(result.batchId);
+      request.clearAll();
     } catch (error) {
       console.log("Media message sending failed with error", error);
     }
@@ -284,25 +366,27 @@ const listener = new CometChat.MediaUploadListener({
 });
 
 const files = (document.getElementById("files") as HTMLInputElement).files!;
-CometChat.uploadFiles(Array.from(files), receiverID, receiverType, listener, { concurrency: 3 });
+const items = Array.from(files).map((file) => ({ fileId: crypto.randomUUID(), file }));
+request.uploadAttachments(items, listener);
 ```
 </Tab>
 
 <Tab title="JavaScript">
 ```javascript
-const uploaded = [];
-
-// Declare the recipient once — used for BOTH the upload authorization and the message.
 const receiverID = "UID";
 const receiverType = CometChat.RECEIVER_TYPE.USER;
 
-const listener = new CometChat.MediaUploadListener({
-  onProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
-  onFileUploaded: (fileId, attachment) => uploaded.push(attachment),
+const request = CometChat.createUploadFileRequest(receiverID, receiverType).setConcurrency(3);
+
+const listener = new CometChat.UploadFileListener({
+  onFileProgress: (fileId, loaded, total, percent) => updateRow(fileId, percent),
   onFileFailure: (fileId, error) => markRetryable(fileId, error),
   onFileError: (fileId, error) => markRejected(fileId, error), // incl. ERR_PERMISSION_DENIED
   onComplete: async (result) => {
-    if (result.successful.length === 0) return;
+    // Wait until nothing is in flight, then send what uploaded successfully.
+    if (request.getStatus() !== CometChat.UploadStatus.IDLE) return;
+    const attachments = request.getAttachments();
+    if (attachments.length === 0) return;
 
     const mediaMessage = new CometChat.MediaMessage(
       receiverID,
@@ -310,12 +394,12 @@ const listener = new CometChat.MediaUploadListener({
       CometChat.MESSAGE_TYPE.FILE,
       receiverType
     );
-    mediaMessage.setAttachments(result.successful.map((s) => s.attachment));
+    mediaMessage.setAttachments(attachments);
 
     try {
       const sent = await CometChat.sendMediaMessage(mediaMessage);
       console.log("Media message sent successfully", sent);
-      CometChat.clearUploadGroup(result.batchId);
+      request.clearAll();
     } catch (error) {
       console.log("Media message sending failed with error", error);
     }
@@ -323,13 +407,14 @@ const listener = new CometChat.MediaUploadListener({
 });
 
 const files = document.getElementById("files").files;
-CometChat.uploadFiles(Array.from(files), receiverID, receiverType, listener, { concurrency: 3 });
+const items = Array.from(files).map((file) => ({ fileId: crypto.randomUUID(), file }));
+request.uploadAttachments(items, listener);
 ```
 </Tab>
 </Tabs>
 
 <Note>
-`sendMediaMessage()` enforces the **maximum attachments per message** (see [Limits](#limits)). If a batch has more successful uploads than the limit allows, split them across multiple `MediaMessage`s. See [Multiple Attachments in a Media Message](/sdk/javascript/send-message#multiple-attachments-in-a-media-message).
+`sendMediaMessage()` enforces the **maximum attachments per message** (see [Limits](#limits)). If a batch has more successful uploads than the limit allows, split them across multiple `MediaMessage`s — grouping by kind with `getAttachmentsByType()` is a natural way to do this. See [Multiple Attachments in a Media Message](/sdk/javascript/send-message#multiple-attachments-in-a-media-message).
 </Note>
 
 ## Limits
@@ -338,10 +423,10 @@ Two independent checks guard the flow, each using a limit read from your app set
 
 | Limit                    | Enforced in            | App setting      | Default    | On breach                                                              |
 | ------------------------ | ---------------------- | ---------------- | ---------- | --------------------------------------------------------------------- |
-| **Per-file size**        | `uploadFiles()`        | `file.size.max`  | 100 MB     | That file is rejected via `onFileError` with `ERR_FILE_SIZE_EXCEEDED`. |
+| **Per-file size**        | `uploadAttachments()`  | `file.size.max`  | 100 MB     | That file is rejected via `onFileError` with `ERR_FILE_SIZE_EXCEEDED`. |
 | **Attachments per message** | `sendMediaMessage()` | `file.count.max` | 10         | `sendMediaMessage()` rejects with `ERR_FILE_COUNT_EXCEEDED`.          |
 
-Read the current attachment-count limit at runtime with `getMaxAttachmentCount()` — useful for disabling the "add file" button in your composer once the user hits the cap:
+Read the current attachment-count limit at runtime with `CometChat.getMaxAttachmentCount()` — useful for disabling the "add file" button in your composer once the user hits the cap:
 
 <Tabs>
 <Tab title="TypeScript">
@@ -360,15 +445,15 @@ console.log("Max attachments per message:", max);
 </Tabs>
 
 <Note>
-The **per-file size** limit is checked in `uploadFiles()` (before the byte transfer), while the **attachment count** limit is checked in `sendMediaMessage()` (when you send). A batch can therefore succeed at upload time but still be rejected at send time if it exceeds the count limit — plan your composer around both.
+The **per-file size** limit is checked at upload time (before the byte transfer), while the **attachment count** limit is checked in `sendMediaMessage()` (when you send). A batch can therefore upload successfully but still be rejected at send time if it exceeds the count limit — plan your composer around both.
 </Note>
 
 ## Reliability behavior
 
 The SDK handles a few transport edge cases for you:
 
-- **Stalled uploads** — if a file makes no progress for 30 seconds, its upload is aborted and reported through `onFileFailure` with `ERR_UPLOAD_STALLED`. Retry it with `retryFileUpload()`.
-- **Expired upload URLs** — the pre-signed upload URL for each file is valid for 15 minutes. `retryFileUpload()` automatically requests a fresh URL if the original has expired, so retries keep working even after a long delay.
+- **Stalled uploads** — if a file makes no progress for 30 seconds, its upload is aborted and reported through `onFileFailure` with `ERR_UPLOAD_STALLED`. Retry it with `retryAttachment()`.
+- **Expired upload URLs** — the pre-signed upload URL for each file is valid for 15 minutes. `retryAttachment()` automatically requests a fresh URL if the original has expired, so retries keep working even after a long delay.
 - **Storage errors** — if storage rejects the upload, the failure surfaces through `onFileFailure` with `ERR_S3_UPLOAD_FAILED` and, where available, the storage's own message.
 
 ## Error handling
@@ -381,12 +466,13 @@ Every error delivered to `onFileError` / `onFileFailure` (and rejections from `s
 | `ERR_FILE_SIZE_EXCEEDED`   | `onFileError`             | No        | The file is larger than `file.size.max`.                          |
 | `ERR_PERMISSION_DENIED`    | `onFileError`             | No        | The sender isn't allowed to upload media to this `receiverId` / `receiverType` (role/scope access control). |
 | `ERR_FILE_COUNT_EXCEEDED`  | `sendMediaMessage()`      | No        | More attachments on the message than `file.count.max` allows.     |
-| `ERR_S3_UPLOAD_FAILED`     | `onFileFailure`, `onFileError` | Yes / No | Storage rejected the upload or the transport errored (`onFileFailure`, retryable); also the fallback when the server declines a file with no specific code (`onFileError`, not retryable). |
+| `ERR_S3_UPLOAD_FAILED`     | `onFileFailure`           | Yes       | Storage rejected the upload, or the transport errored.            |
 | `ERR_PRESIGNED_URL_EXPIRED`| `onFileFailure`           | Yes       | The pre-signed URL expired (a retry re-presigns automatically).   |
 | `ERR_UPLOAD_STALLED`       | `onFileFailure`           | Yes       | No progress for 30s; the upload was aborted.                      |
-| `ERR_UPLOAD_CANCELLED`     | —                         | —         | The upload was cancelled via `cancelFileUpload()`.                |
 
+<Note>
 `ERR_PERMISSION_DENIED` is returned by the server's access-control check, so its exact code and message come from your backend. See the full list on the [Error Codes](/sdk/javascript/error-codes#media-upload-errors) page.
+</Note>
 
 ## Next Steps
 

--- a/sdk/javascript/upload-files.mdx
+++ b/sdk/javascript/upload-files.mdx
@@ -465,13 +465,14 @@ Every error delivered to `onFileError` / `onFileFailure` (and rejections from `s
 | `ERR_INVALID_FILE_OBJECT`  | `onFileError`             | No        | The file is invalid or its size can't be determined.              |
 | `ERR_FILE_SIZE_EXCEEDED`   | `onFileError`             | No        | The file is larger than `file.size.max`.                          |
 | `ERR_PERMISSION_DENIED`    | `onFileError`             | No        | The sender isn't allowed to upload media to this `receiverId` / `receiverType` (role/scope access control). |
+| `ERR_BAD_REQUEST`          | `onFileError`             | No        | The server rejected the presign request for this file — e.g. a corrupted or otherwise invalid file. |
 | `ERR_FILE_COUNT_EXCEEDED`  | `sendMediaMessage()`      | No        | More attachments on the message than `file.count.max` allows.     |
 | `ERR_S3_UPLOAD_FAILED`     | `onFileFailure`, `onFileError` | Yes / No | Storage rejected the upload or the transport errored (`onFileFailure`, retryable); also the fallback when the server declines a file with no specific code (`onFileError`, not retryable). |
 | `ERR_PRESIGNED_URL_EXPIRED`| `onFileFailure`           | Yes       | The pre-signed URL expired (a retry re-presigns automatically).   |
 | `ERR_UPLOAD_STALLED`       | `onFileFailure`           | Yes       | No progress for 30s; the upload was aborted.                      |
 
 <Note>
-`ERR_PERMISSION_DENIED` is returned by the server's access-control check, so its exact code and message come from your backend. See the full list on the [Error Codes](/sdk/javascript/error-codes#media-upload-errors) page.
+`ERR_PERMISSION_DENIED` and `ERR_BAD_REQUEST` are returned by the server's presign check, so their exact code and message come from your backend. See the full list on the [Error Codes](/sdk/javascript/error-codes#media-upload-errors) page.
 </Note>
 
 ## Next Steps

--- a/sdk/javascript/upload-files.mdx
+++ b/sdk/javascript/upload-files.mdx
@@ -149,7 +149,7 @@ request.uploadAttachments(items, listener);
 <Note>
 **`fileId` is caller-supplied and required.** The SDK does not generate one — you provide a stable id per file (echoed back unchanged on every event) so you can line each file up with its UI row. A `fileId` already present in the batch is **silently skipped** (deduped), so re-adding the same file is a no-op. `file` must be a platform-native `File`/`Blob` (the pipeline needs a numeric `size`).
 
-Validation, presigning, and the byte transfer all run **asynchronously** after `uploadAttachments()` returns — track outcomes through the listener.
+Validation, presigning, and the byte transfer all run **asynchronously** after `uploadAttachments()` returns — track outcomes through the listener. Each file is presigned and uploaded **independently**, so one file being rejected or failing never affects the others in the batch.
 </Note>
 
 ## The UploadFileListener
@@ -318,7 +318,7 @@ request.clearAll();
 | Method                     | Behavior                                                                                                                    |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `removeAttachment(fileId)` | Removes one file from the batch. If it's still uploading, the transfer is aborted **silently** (no `onFileFailure`); if it already uploaded, it's dropped from the set. |
-| `retryAttachment(fileId)`  | Re-uploads one **failed** file, re-presigning first if the earlier upload URL expired. No-op for rejected or uploaded files. |
+| `retryAttachment(fileId)`  | Re-uploads one **failed** file, re-presigning first if the earlier upload URL expired. No-op for already-rejected or uploaded files. |
 | `clearAll()`               | Aborts any in-flight uploads and drops the whole batch from SDK memory.                                                     |
 
 <Note>
@@ -453,7 +453,7 @@ The **per-file size** limit is checked at upload time (before the byte transfer)
 The SDK handles a few transport edge cases for you:
 
 - **Stalled uploads** — if a file makes no progress for 30 seconds, its upload is aborted and reported through `onFileFailure` with `ERR_UPLOAD_STALLED`. Retry it with `retryAttachment()`.
-- **Expired upload URLs** — the pre-signed upload URL for each file is valid for 15 minutes. `retryAttachment()` automatically requests a fresh URL if the original has expired, so retries keep working even after a long delay.
+- **Expired upload URLs** — the pre-signed upload URL for each file is valid for 15 minutes. `retryAttachment()` automatically requests a fresh URL if the original has expired, so retries keep working even after a long delay. If that fresh request is permanently denied (e.g. permissions changed), the file moves to **rejected** (`onFileError`) rather than looping as a failure.
 - **Storage errors** — if storage rejects the upload, the failure surfaces through `onFileFailure` with `ERR_S3_UPLOAD_FAILED` and, where available, the storage's own message.
 
 ## Error handling
@@ -466,7 +466,7 @@ Every error delivered to `onFileError` / `onFileFailure` (and rejections from `s
 | `ERR_FILE_SIZE_EXCEEDED`   | `onFileError`             | No        | The file is larger than `file.size.max`.                          |
 | `ERR_PERMISSION_DENIED`    | `onFileError`             | No        | The sender isn't allowed to upload media to this `receiverId` / `receiverType` (role/scope access control). |
 | `ERR_FILE_COUNT_EXCEEDED`  | `sendMediaMessage()`      | No        | More attachments on the message than `file.count.max` allows.     |
-| `ERR_S3_UPLOAD_FAILED`     | `onFileFailure`           | Yes       | Storage rejected the upload, or the transport errored.            |
+| `ERR_S3_UPLOAD_FAILED`     | `onFileFailure`, `onFileError` | Yes / No | Storage rejected the upload or the transport errored (`onFileFailure`, retryable); also the fallback when the server declines a file with no specific code (`onFileError`, not retryable). |
 | `ERR_PRESIGNED_URL_EXPIRED`| `onFileFailure`           | Yes       | The pre-signed URL expired (a retry re-presigns automatically).   |
 | `ERR_UPLOAD_STALLED`       | `onFileFailure`           | Yes       | No progress for 30s; the upload was aborted.                      |
 


### PR DESCRIPTION
## Description

- Add new "Upload Files & Send Attachments" guide documenting CometChat.uploadFiles() flow with per-file progress, cancel, and retry
- Add "Upload Files" page to JavaScript SDK Messaging section in docs.json
- Document Media Upload error category and specific error codes (ERR_INVALID_FILE_OBJECT, ERR_FILE_SIZE_EXCEEDED, ERR_FILE_COUNT_EXCEEDED, ERR_S3_UPLOAD_FAILED, ERR_PRESIGNED_URL_EXPIRED, ERR_UPLOAD_STALLED, ERR_UPLOAD_CANCELLED) in error-codes.mdx
- Update send-message.mdx to recommend upload-first pattern for multi-attachment composers and link to new upload guide
- Add CometChat.getMaxAttachmentCount() runtime API reference for checking attachment limits
- Clarify distinction between rejected (non-retryable) and failed (retryable) upload errors with MediaUploadListener callback mapping

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [ ] Documentation correction/update
- [x] New documentation
- [ ] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
