### PR TITLE
docs(flutter-uikit-v5): add video thumbnail troubleshooting

### DIFF
--- a/ui-kit/flutter/v5/troubleshooting.mdx
+++ b/ui-kit/flutter/v5/troubleshooting.mdx
@@ -120,8 +120,8 @@ dependency_overrides:
 Then reinstall dependencies and do a clean rebuild:
 
 ```bash
-flutter pub get
 flutter clean
+flutter pub get
 ```
 
 <Note>

--- a/ui-kit/flutter/v5/troubleshooting.mdx
+++ b/ui-kit/flutter/v5/troubleshooting.mdx
@@ -100,6 +100,33 @@ description: "Common failure modes and fixes for the CometChat Flutter UI Kit."
 | Polls option missing | Polls extension not enabled | Activate [Polls Extension](/fundamentals/polls) in Dashboard |
 | Link preview not rendering | Link Preview extension not enabled | Activate [Link Preview Extension](/fundamentals/link-preview) in Dashboard |
 | Reactions not working | Reactions extension not enabled | Activate [Reactions Extension](/fundamentals/reactions) in Dashboard |
+| Video thumbnails show a grey box (image thumbnails render fine) | The default v4 Chat SDK does not pass the generated thumbnail URL correctly, so it fails to load | Override `cometchat_sdk` to `5.0.4`, see [Video thumbnails not rendering](#video-thumbnails-not-rendering) below |
+
+---
+
+### Video thumbnails not rendering
+
+With Flutter UI Kit `5.2.x`, the message list resolves the Thumbnail Generation extension's `cometchat_sdk` (the v4 Chat SDK) by default. On that version, the generated thumbnail URL is not passed correctly, so video thumbnails fail to load and fall back to a grey box with a play icon.
+
+Image thumbnails are unaffected because they fall back to the full image URL, which is why only videos appear broken.
+
+This is resolved in the v5 Chat SDK. Since the UI Kit still resolves the v4 SDK by default, pin the SDK version using `dependency_overrides` in your app's `pubspec.yaml`:
+
+```yaml
+dependency_overrides:
+  cometchat_sdk: 5.0.4
+```
+
+Then reinstall dependencies and do a clean rebuild:
+
+```bash
+flutter pub get
+flutter clean
+```
+
+<Note>
+Use version `5.0.4` specifically. Avoid overriding to the latest v5 SDK, as newer releases include changes that can cause compile-time issues with UI Kit `5.2.x`.
+</Note>
 
 ---
 


### PR DESCRIPTION
## Description 

<!-- Please include a summary of the changes and relevant context. -->

Adds a troubleshooting entry for a known issue where video thumbnails render as a grey box in the Flutter UI Kit 5.2.x, while image thumbnails display correctly.

The default cometchat_sdk (v4 Chat SDK) resolved by UI Kit 5.2.x does not pass the generated thumbnail URL correctly, so video thumbnails fail to load. This is fixed in the v5 Chat SDK. Since the UI Kit still resolves the v4 SDK by default, the entry documents the dependency_overrides workaround (pin cometchat_sdk to 5.0.4), including why 5.0.4 specifically rather than the latest v5.

Changes: one file : ui-kit/flutter/v5/troubleshooting.mdx

New row in the Extensions table (symptom → cause → fix)
New ### Video thumbnails not rendering sub-section with the override snippet, rebuild steps, and a <Note> on the version pin

## Related Issue(s)
<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

Linear: ENG-37272 — Docs gap: Flutter UIKit 5.2.x video thumbnails with v4 Chat SDK — cometchat_sdk 5.0.4 override workaround is undocumented. (No corresponding GitHub issue; tracked in Linear.)

## Type of Change
<!-- Please check the relevant options by putting an "x" in the brackets -->

- [ ] Documentation correction/update
- [ ] New documentation
- [x] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist
<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information
<!-- Any additional information or context about the changes -->

Scoped to the v5 docs (ui-kit/flutter/v5/) only, 5.2.x is the v5 UI Kit line. The top-level (V6) docs are not affected, as V6 resolves the v5 Chat SDK by default (which already contains the fix).

Note on the fix version: the underlying URL-passing fix is present in the v5 Chat SDK from 5.0.1 onward; 5.0.4 is recommended purely as the safe pin for UI Kit 5.2.x compatibility (later v5 releases can introduce compile-time issues with the v5 UI Kit).