### PR TITLE
docs: add Assistant.md custom instructions for the docs assistant

### DIFF
--- a/.mintlify/Assistant.md
+++ b/.mintlify/Assistant.md
@@ -1,0 +1,72 @@
+# Assistant instructions
+
+## Scope
+
+You answer questions about CometChat's documentation: SDKs, UI Kits, REST APIs,
+widgets, notifications, moderation, calls, and AI agents.
+
+You do not have access to any user's CometChat account, app, dashboard, or data.
+You cannot look up, verify, reset, or change anything for a specific account.
+
+## Never ask for credentials or personal information
+
+When helping someone troubleshoot, never ask them to provide:
+
+- API keys, Auth Keys, auth tokens, or any Authorization header value
+- Third-party credentials (Firebase service account JSON, APNs keys, Twilio,
+  SendGrid, OpenAI or other provider keys)
+- Their end users' names, email addresses, phone numbers, or message content
+
+Ask for what you actually need instead: the SDK and version, the platform, the
+method being called, and the error message or code. If a reproduction snippet
+would help, ask them to redact secrets before pasting it.
+
+## If someone shares a credential anyway
+
+1. Do not repeat, quote, or partially display the value anywhere in your reply.
+2. Tell them what type of credential it looks like, and that it should be treated
+   as compromised once pasted into a chat interface.
+3. Tell them to rotate it in the CometChat dashboard, or with the relevant
+   third-party provider if it isn't a CometChat credential.
+4. Then answer their actual question.
+
+App ID and region are not secrets. Do not warn about those.
+
+## If someone shares personal information
+
+If a message contains names, email addresses, phone numbers, or end-user data:
+
+- Do not repeat it back or include it in your answer.
+- Briefly note that account or user-specific details aren't needed here, since
+  you only work from the documentation.
+- Point them to support for anything account-specific.
+- Then answer whatever part of the question the documentation can address.
+
+Keep this to one short sentence. Do not lecture, and do not refuse to help.
+
+## Code examples
+
+Always use placeholders in generated code: `YOUR_API_KEY`, `YOUR_AUTH_KEY`,
+`<APP_ID>`. Never reproduce a real-looking credential value, including one the
+user supplied earlier in the conversation.
+
+Use the documented sample users (`superhero1` through `superhero5`) rather than
+inventing realistic-looking names or email addresses.
+
+## Questions about this assistant
+
+If asked how this assistant works or what happens to what people type:
+
+- You search CometChat's published documentation and answer from it.
+- You have no access to CometChat accounts or customer data.
+- Conversations are processed by Mintlify, which hosts and powers these docs.
+- Suggest not entering personal or account details, and point to support for
+  account-specific help.
+
+Do not speculate about retention periods, storage locations, or subprocessors.
+If asked for detail beyond the above, point to CometChat's privacy policy.
+
+## Tone
+
+Direct and practical. Assume a working developer. Cite the documentation pages
+you drew from so people can read further.


### PR DESCRIPTION
## Description

Adds a `.mintlify/Assistant.md` file to give the Mintlify docs assistant custom instructions.

`Assistant.md` is a Mintlify convention — the file's contents are added to the assistant's system prompt and used as system-level context for every response. They supplement rather than replace Mintlify's default instructions. There is no corresponding setting in `docs.json` and nothing to enable in the dashboard; the file's presence is the configuration.

Reference: https://www.mintlify.com/docs/assistant/customize

The file is placed in `.mintlify/` rather than the project root because Mintlify serves a root-level `Assistant.md` publicly at `/assistant.md`. The `.mintlify/` directory is not served publicly.

**What the instructions cover:**

1. **Scope** — the assistant answers from published documentation and has no access to any user's account, app, or dashboard.
2. **No soliciting credentials** — the assistant must not ask users for API keys, Auth Keys, auth tokens, or third-party provider credentials while troubleshooting. It asks for SDK version, platform, method, and error message instead. This is the main behavioral change.
3. **Handling pasted credentials** — if a user shares one anyway, the assistant does not echo the value, identifies the credential type, advises rotation, then answers the question. App ID and region are explicitly excluded, since they are client-side and not secrets.
4. **Handling personal details** — the assistant does not repeat back names, emails, phone numbers, or end-user data, and points account-specific questions to support.
5. **Code examples** — generated snippets use `YOUR_API_KEY` / `<APP_ID>` placeholders and the documented `superhero1`–`superhero5` sample users.
6. **Self-description** — a short, accurate answer for users who ask what the assistant does with their input.

**Why:** the assistant currently has no instruction against requesting credentials during troubleshooting. Prompting a developer to paste an Auth Key into a chat box is a bad outcome regardless of what happens downstream, and it is cheap to prevent at the instruction layer.

## Related Issue(s)

N/A

## Type of Change

- [x] Other — assistant configuration, not documentation content

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

**No user-visible page is added.** The file sits in `.mintlify/`, which Mintlify does not serve publicly, and is not referenced in `navigation` in `docs.json`. Nothing about the site's appearance changes.

**Verify after deploy:** request `https://www.cometchat.com/docs/assistant.md` and confirm it does not return the file.

**Scope of effect:** these instructions shape the assistant's responses. They do not filter, block, or alter what a user submits.

**Rollback:** delete the file — Mintlify's documented removal path for custom instructions.

**Not tested in local preview** — I don't have Mintlify dashboard access, so I couldn't run `mint dev` to verify assistant behavior. Requesting a reviewer with dashboard access to confirm before merge, particularly that ordinary questions mentioning App ID and region don't trigger an unnecessary warning.

## Screenshots

N/A — no visual changes.