### PR TITLE
docs(android-uikit-v6): revamp Overview for dual toolkit + fix minSdk/version inconsistencies

### DIFF
--- a/ui-kit/android/v6/getting-started.mdx
+++ b/ui-kit/android/v6/getting-started.mdx
@@ -16,7 +16,7 @@ description: "Install, configure, and launch the CometChat Android UI Kit in you
 | Auth Key | Dev/testing only. Use Auth Token in production |
 | Theme | Set `CometChatTheme.DayNight` as parent theme in `themes.xml` |
 | Calling | Optional. Add `com.cometchat:calls-sdk-android` to enable voice/video |
-| Min SDK | Android 7.0 (API 24) |
+| Min SDK | Android 9.0 (API 28) |
 
 </Accordion>
 
@@ -40,7 +40,7 @@ You need three things from the [CometChat Dashboard](https://app.cometchat.com/)
 
 You also need:
 - Android Studio installed
-- An Android emulator or physical device running Android 7.0 (API 24) or higher
+- An Android emulator or physical device running Android 9.0 (API 28) or higher
 - Java 8 or higher
 - Gradle plugin 4.0.1 or later
 

--- a/ui-kit/android/v6/guide-block-unblock-user.mdx
+++ b/ui-kit/android/v6/guide-block-unblock-user.mdx
@@ -15,7 +15,7 @@ description: "Let users block and unblock others directly within chat to control
 
 </Accordion>
 
-Enable users to block and unblock others directly within chat using CometChat's Android UI Kit v5+, preventing unwanted communication and giving users more control.
+Enable users to block and unblock others directly within chat using CometChat's Android UI Kit v6+, preventing unwanted communication and giving users more control.
 
 ## Overview
 
@@ -27,7 +27,7 @@ Blocking a user stops them from sending messages to the blocker. The CometChat U
 
 ## Prerequisites
 
-- Android Studio project with CometChat Android UI Kit v5 added to `build.gradle`.  
+- Android Studio project with CometChat Android UI Kit v6 added to `build.gradle`.  
 - CometChat **App ID**, **Auth Key**, and **Region** configured and initialized.  
 - `<uses-permission android:name="android.permission.INTERNET"/>` in `AndroidManifest.xml`.  
 - Logged-in user via `CometChatUIKit.login()`.  

--- a/ui-kit/android/v6/guide-call-log-details.mdx
+++ b/ui-kit/android/v6/guide-call-log-details.mdx
@@ -30,8 +30,8 @@ This feature is essential for support, moderation, and post-call reviews.
 
 ## Prerequisites
 
-- Android Studio project targeting API 24+.  
-- **CometChat Android UI Kit v5** (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) and **CometChat Calls SDK** added in `build.gradle`.  
+- Android Studio project targeting API 28+.  
+- **CometChat Android UI Kit v6** (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) and **CometChat Calls SDK** added in `build.gradle`.  
 - A logged-in CometChat user (`CometChat.getLoggedInUser()` non-null).  
 - Required permissions in `AndroidManifest.xml`: Internet, Camera, Microphone.  
 - ViewBinding enabled or equivalent view setup.

--- a/ui-kit/android/v6/guide-group-chat.mdx
+++ b/ui-kit/android/v6/guide-group-chat.mdx
@@ -15,7 +15,7 @@ description: "Implement group creation, joining, member management, banning, sco
 
 </Accordion>
 
-Enable seven core group-management features in your Android app using CometChat UIKit v5:
+Enable seven core group-management features in your Android app using CometChat UIKit v6:
 
 - **Create Group**
 - **Join Group**
@@ -40,7 +40,7 @@ Typically, a FloatingActionButton (FAB) or menu item launches the group-manageme
 
 ## Prerequisites
 
-- Android Studio project with **CometChat Android UI Kit v5** (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) and **CometChat Chat SDK** in `build.gradle`.  
+- Android Studio project with **CometChat Android UI Kit v6** (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) and **CometChat Chat SDK** in `build.gradle`.  
 - Internet permission in `AndroidManifest.xml`.  
 - Valid CometChat **App ID**, **Region**, and **Auth Key** configured via `UIKitSettings`.  
 - User logged in with `CometChatUIKit.login()`.  

--- a/ui-kit/android/v6/guide-message-privately.mdx
+++ b/ui-kit/android/v6/guide-message-privately.mdx
@@ -29,7 +29,7 @@ Users tap **Message Privately** → launch `MessagesActivity` with the target us
 
 ## Prerequisites
 
-- Android Studio project with CometChat Android UI Kit v5 (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) added to `build.gradle`.  
+- Android Studio project with CometChat Android UI Kit v6 (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) added to `build.gradle`.  
 - Valid CometChat **App ID**, **Auth Key**, and **Region** initialized.  
 - `<uses-permission android:name="android.permission.INTERNET"/>` in `AndroidManifest.xml`.  
 - Users created in your CometChat app.  

--- a/ui-kit/android/v6/guide-new-chat.mdx
+++ b/ui-kit/android/v6/guide-new-chat.mdx
@@ -29,7 +29,7 @@ This streamlines contact/group discovery and boosts engagement by reducing frict
 
 ## Prerequisites
 
-- Android project with **CometChat UIKit Android v5** (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) added in `build.gradle`.  
+- Android project with **CometChat UIKit Android v6** (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) added in `build.gradle`.  
 - CometChat credentials (**App ID**, **Auth Key**, **Region**) initialized.  
 - Navigation configured: `ConversationActivity` → `NewChatActivity` → `MessagesActivity`.  
 - Internet and network permissions granted in `AndroidManifest.xml`.

--- a/ui-kit/android/v6/guide-threaded-messages.mdx
+++ b/ui-kit/android/v6/guide-threaded-messages.mdx
@@ -30,7 +30,7 @@ Users tap a message → open thread screen → view parent message + replies →
 ## Prerequisites
 
 - Android project in Android Studio.  
-- CometChat Android UI Kit v5 (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) added to your `build.gradle`.  
+- CometChat Android UI Kit v6 (`com.cometchat:chatuikit-kotlin` or `com.cometchat:chatuikit-jetpack`) added to your `build.gradle`.  
 - Valid CometChat **App ID**, **Auth Key**, and **Region** initialized.  
 - `<uses-permission android:name="android.permission.INTERNET"/>` in `AndroidManifest.xml`.  
 - Logged-in user via `CometChatUIKit.login()`.  

--- a/ui-kit/android/v6/overview.mdx
+++ b/ui-kit/android/v6/overview.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Android UI Kit"
 sidebarTitle: "Overview"
-description: "Prebuilt Android Views for chat & messaging, voice & video calling. Supports Kotlin with XML Views and Jetpack Compose."
+description: "Prebuilt, customizable UI components for chat & messaging, voice & video calling — for both Jetpack Compose and Kotlin XML Views."
 ---
 
 <Accordion title="AI Integration Quick Reference">
@@ -11,13 +11,18 @@ description: "Prebuilt Android Views for chat & messaging, voice & video calling
 | Kotlin (XML Views) | `com.cometchat:chatuikit-kotlin-android` v6.x |
 | Jetpack Compose | `com.cometchat:chatuikit-compose-android` v6.x |
 | Shared core | `chatuikit-core` (ViewModels, repositories, data sources, events) |
-| Peer deps | `com.cometchat:chat-sdk-android` >=4.x, `minSdk` 24 |
+| Peer deps | `com.cometchat:chat-sdk-android` >=4.x, `minSdk` 28 |
 | Calling | Optional — `com.cometchat:calls-sdk-android` |
 | Source | [GitHub](https://github.com/cometchat/cometchat-uikit-android) |
 
 </Accordion>
 
-The CometChat Android UI Kit provides prebuilt, customizable Views for adding chat, voice, and video calling to any Android app. Each component handles its own data fetching, real-time listeners, and state — you just drop them into your layout.
+The CometChat Android UI Kit provides prebuilt, customizable UI components for adding chat, voice, and video calling to any Android app. Every component handles its own data fetching, real-time listeners, and state — so you drop it in and it works.
+
+It ships in two flavors that share the same core (ViewModels, repositories, events), so you get identical behavior whichever you choose:
+
+- **Jetpack Compose** — native Material 3 composables for modern, Compose-first apps.
+- **Kotlin (XML Views)** — drop-in Views for existing XML layout–based apps.
 
 <Frame>
   <img src="/images/4c141125-Instant_Messaging-3e86359342605c94dc912604de8f6617.png" />
@@ -25,9 +30,30 @@ The CometChat Android UI Kit provides prebuilt, customizable Views for adding ch
 
 ---
 
+## Get Started
+
+Every integration starts the same way — install the SDK, initialize, and log in — then you build the UI with your chosen toolkit. Start with the prerequisites, then pick a path:
+
+<Card title="Prerequisites & Setup" icon="key" href="/ui-kit/android/v6/getting-started">
+  App credentials, Gradle install, `init()`, and `login()` — shared by both toolkits
+</Card>
+
+<CardGroup cols={2}>
+  <Card title="Jetpack Compose" icon="layer-group" href="/ui-kit/android/v6/getting-started-jetpack">
+    Build your chat UI with native Material 3 composables
+  </Card>
+  <Card title="Kotlin (XML Views)" icon="file-code" href="/ui-kit/android/v6/getting-started-kotlin">
+    Build your chat UI with drop-in XML Views
+  </Card>
+</CardGroup>
+
+---
+
 ## Try It
 
-<CardGroup>
+See the UI Kit in action before you write any code:
+
+<CardGroup cols={2}>
   <Card title="Google Play Demo" icon="play" href="https://link.cometchat.com/android-demo-app">
     Try the full chat experience on your device
   </Card>
@@ -36,7 +62,7 @@ The CometChat Android UI Kit provides prebuilt, customizable Views for adding ch
   </Card>
 </CardGroup>
 
-### Download the CometChat Demo App
+Download the CometChat demo app from Google Play:
 
 [<img src="/images/7f1e19fd-google-play-badge-f2deddb3d9c4b7c784e35f3a7794f994.png" />](https://link.cometchat.com/android-demo-app)
 
@@ -45,21 +71,6 @@ Or scan the QR code to install directly:
 <Frame>
   <img src="/images/844ec598-qr_code-3437240f18ec2f1548a04ebc93e8ce4e.png" />
 </Frame>
-
----
-
-## Get Started
-
-Follow the step-by-step integration guide to add the UI Kit to your Android project:
-
-<CardGroup cols={2}>
-  <Card title="Integration Guide" icon="rocket" href="/ui-kit/android/v6/getting-started">
-    Gradle setup, initialization, and login
-  </Card>
-  <Card title="Key Concepts" icon="lightbulb" href="/fundamentals/key-concepts">
-    Essential terminology and platform features
-  </Card>
-</CardGroup>
 
 ---
 
@@ -78,6 +89,12 @@ Follow the step-by-step integration guide to add the UI Kit to your Android proj
   <Card title="Guides" icon="book" href="/ui-kit/android/v6/guide-overview">
     Threaded messages, new chat, search, and more
   </Card>
+  <Card title="Key Concepts" icon="lightbulb" href="/fundamentals/key-concepts">
+    Essential terminology and platform features
+  </Card>
+  <Card title="Architecture" icon="sitemap" href="/ui-kit/android/v6/architecture-data-flow">
+    How components, ViewModels, and data flow fit together
+  </Card>
 </CardGroup>
 
 ---
@@ -88,19 +105,16 @@ Follow the step-by-step integration guide to add the UI Kit to your Android proj
   <Card title="Sample App" icon="github" href="https://github.com/cometchat/cometchat-uikit-android">
     Working reference app
   </Card>
-  <Card title="Source Code" icon="code" href="https://github.com/cometchat/cometchat-uikit-android">
-    Full UI Kit source on GitHub
-  </Card>
   <Card title="Figma" icon="figma" href="https://www.figma.com/community/file/1444324233177163609/cometchat-ui-kit-for-android">
     Design resources and prototyping
+  </Card>
+  <Card title="Migration Guide" icon="arrow-up" href="/ui-kit/android/v6/upgrading-from-v5">
+    Upgrading from v5
   </Card>
   <Card title="Troubleshooting" icon="wrench" href="/ui-kit/android/v6/troubleshooting">
     Common issues and fixes
   </Card>
   <Card title="Support" icon="headset" href="https://help.cometchat.com/hc/en-us/requests/new">
     Open a support ticket
-  </Card>
-  <Card title="Migration Guide" icon="arrow-up" href="/ui-kit/android/v6/upgrading-from-v5">
-    Upgrading from v5
   </Card>
 </CardGroup>

--- a/ui-kit/android/v6/troubleshooting.mdx
+++ b/ui-kit/android/v6/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Troubleshooting"
-description: "Common failure modes and fixes for the CometChat Android V5 UI Kit."
+description: "Common failure modes and fixes for the CometChat Android V6 UI Kit."
 ---
 
 <Accordion title="AI Integration Quick Reference">
@@ -9,7 +9,7 @@ description: "Common failure modes and fixes for the CometChat Android V5 UI Kit
 | --- | --- |
 | Page type | Troubleshooting reference |
 | Packages | `com.cometchat:chatuikit-kotlin` · `com.cometchat:chatuikit-jetpack` |
-| Scope | All CometChat Android UI Kit v5 issues — initialization, theming, components, calling, extensions, AI features, localization, sound, events, methods, text formatters |
+| Scope | All CometChat Android UI Kit v6 issues — initialization, theming, components, calling, extensions, AI features, localization, sound, events, methods, text formatters |
 | When to reference | When a component fails to render, data is missing, styling doesn't apply, or a feature doesn't appear |
 
 </Accordion>
@@ -25,7 +25,7 @@ description: "Common failure modes and fixes for the CometChat Android V5 UI Kit
 | `getLoggedInUser()` returns null | User not logged in or session expired | Call `login()` or `loginWithAuthToken()` first |
 | Auth Key exposed in production | Using Auth Key instead of Auth Token | Switch to [`loginWithAuthToken()`](/ui-kit/android/v6/methods#login-using-auth-token) for production. Generate tokens server-side via the REST API |
 | `init()` callback never fires | Network blocked or incorrect region | Verify internet permission in `AndroidManifest.xml` and confirm the region matches your Dashboard (`us`, `eu`, `in`) |
-| `minSdk` build error | Project `minSdk` is below 24 | Set `minSdk` to 24 or higher in your app-level `build.gradle` — the UI Kit requires Android 7.0 (API 24)+ |
+| `minSdk` build error | Project `minSdk` is below 28 | Set `minSdk` to 28 or higher in your app-level `build.gradle` — the UI Kit requires Android 9.0 (API 28)+ |
 | Dependency resolution failure | Missing CometChat Maven repository | Add `maven("https://dl.cloudsmith.io/public/cometchat/cometchat/maven/")` to `settings.gradle` repositories block |
 | Wrong import for `CometChatUIKit` | Using old package path | Use `import com.cometchat.uikit.core.CometChatUIKit` for both `chatuikit-kotlin` and `chatuikit-jetpack` modules |
 


### PR DESCRIPTION
## Summary

Revamps the **Android UI Kit v6 Overview** to present the two integration toolkits (Jetpack Compose and Kotlin/XML Views) as a first-class choice, and fixes a set of cross-page inconsistencies discovered while reviewing it.

### Overview page (`ui-kit/android/v6/overview.mdx`)
- Reworked the hero copy to be **toolkit-neutral** (was View/XML-only framing) and to state both flavors up front — they share the same core (ViewModels, repositories, events).
- Replaced the single generic **"Integration Guide"** card with an **equal-weight Get Started fork**: **Jetpack Compose** ↔ **Kotlin (XML Views)**, plus a shared **Prerequisites & Setup** card.
- Moved *Get Started* above *Try It* (decision first), expanded *Explore* (added Key Concepts + Architecture), de-duplicated *Resources*.

### Cross-page consistency fixes (v6 tree)
- **`minSdk` → Android 9.0 (API 28)** everywhere. The two toolkit getting-started guides already required 28, while `overview`, base `getting-started`, `troubleshooting`, and `guide-call-log-details` still said API 24. The troubleshooting page also gave the **wrong remediation** ("set minSdk to 24") — corrected to 28.
- **Stale `v5` labels → `v6`.** Fixed copy-paste leftovers from the v5 docs across `troubleshooting` + 6 guide pages. Legit references preserved: the *Upgrading from v5* migration card and the *"renamed in v5"* historical note.

## Verification
- ✅ Build safe — no `docs.json`/nav changes; all 9 changed files remain nav-referenced (no orphans).
- ✅ **0** stale `API 24` / `Android 7.0` references remain — all at API 28.
- ✅ **0** stale kit `v5` labels remain (legit migration/rename refs preserved).
- ✅ All internal links and images in the revamped overview resolve on-branch.
- ✅ Rendered and reviewed locally via `mint dev`.

## Out of scope (flagged, intentionally not changed)
A separate package-name split exists in the v6 docs — prose uses `chatuikit-kotlin` / `chatuikit-jetpack` while install snippets use `chatuikit-kotlin-android` / `chatuikit-compose-android`. Left untouched pending confirmation of the canonical published artifact names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)