### PR TITLE
docs(sdk/ios): update Cards installation for the 1.2.0 dynamic framework

### DIFF
--- a/sdk/ios/campaigns.mdx
+++ b/sdk/ios/campaigns.mdx
@@ -70,7 +70,9 @@ If you use `CometChatNotificationFeed` (UI Kit), the Cards library is used inter
 
 ### Installation
 
-Requires **iOS 15.1 or later**.
+Requires **iOS 15.1 or later** — higher than the Chat SDK's own minimum, so set your target's **iOS Deployment Target** to 15.1 before adding the library. With CocoaPods, your Podfile must also declare `platform :ios, '15.1'`.
+
+Leaving the deployment target lower makes `pod install` fail with a platform-incompatibility error, and Swift Package Manager refuses to resolve the package.
 
 **Swift Package Manager**
 

--- a/sdk/ios/campaigns.mdx
+++ b/sdk/ios/campaigns.mdx
@@ -70,12 +70,14 @@ If you use `CometChatNotificationFeed` (UI Kit), the Cards library is used inter
 
 ### Installation
 
+Requires **iOS 15.1 or later**.
+
 **Swift Package Manager**
 
 In Xcode: **File → Add Package Dependencies** → enter:
 
 ```
-https://github.com/cometchat/cometchat-cards-sdk-ios
+https://github.com/cometchat/cards-sdk-ios
 ```
 
 Add `CometChatCardsSwift` to your target.
@@ -83,12 +85,20 @@ Add `CometChatCardsSwift` to your target.
 **CocoaPods**
 
 ```ruby
-pod 'CometChatCardsSwift'
+pod 'CometChatCardsSwift', '~> 1.2'
 ```
 
 ```bash
 pod install
 ```
+
+Both Swift Package Manager and CocoaPods embed and code-sign the framework for you — no extra configuration is needed.
+
+<Warning>
+If you integrate the `.xcframework` **manually** instead, set it to **Embed & Sign** in your target's *Frameworks, Libraries, and Embedded Content* settings.
+
+From version 1.2.0 `CometChatCardsSwift` ships as a *dynamic* framework; earlier versions were static and used "Do Not Embed". With "Do Not Embed" the app still compiles and links, then crashes on launch with `Library not loaded: @rpath/CometChatCardsSwift.framework/CometChatCardsSwift`.
+</Warning>
 
 No initialization is required. The library is stateless — import it and start rendering.
 


### PR DESCRIPTION
CometChatCardsSwift 1.2.0 ships as a dynamic framework; 1.1.0 and earlier were static (`ar archive`). Manual .xcframework integrations that used "Do Not Embed" still compile and link, then crash at launch with
`Library not loaded: @rpath/CometChatCardsSwift.framework/CometChatCardsSwift`, so the embedding requirement is now called out explicitly.

- State the iOS 15.1 minimum (1.2.0 is built at that deployment target, and both Package.swift and the podspec declare it)
- Correct the Swift Package Manager URL: the repository is cards-sdk-ios, not cometchat-cards-sdk-ios
- Pin the CocoaPods example to '~> 1.2'
- Note that SPM and CocoaPods handle embedding and signing automatically, and warn that manual integration needs Embed & Sign

Verified against the published 1.2.0 artifact: minos 15.1, Mach-O dynamically linked shared library, install name @rpath/CometChatCardsSwift.framework/…, and 1.2.0 is live on CocoaPods trunk.

## Description

<!-- Please include a summary of the changes and relevant context. -->

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

<!-- Please check the relevant options by putting an "x" in the brackets -->

- [ ] Documentation correction/update
- [ ] New documentation
- [x] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

<!-- Please check all applicable items by putting an "x" in the brackets -->

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

<!-- Any additional information or context about the changes -->

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
