### PR TITLE
docs(notifications): fix broken push-integration route + clarify Provider ID setup

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -7124,6 +7124,10 @@
       "destination": "/notifications/push-overview"
     },
     {
+      "source": "/notifications/push-integration",
+      "destination": "/notifications/push-overview"
+    },
+    {
       "source": "/ui-kit/react/v6",
       "destination": "/ui-kit/react/v6/overview"
     },

--- a/notifications/android-push-notifications.mdx
+++ b/notifications/android-push-notifications.mdx
@@ -557,7 +557,7 @@ CometChat's Enhanced Push Notification payload includes an `unreadMessageCount` 
 
 ### 8.1 Enable unread badge count on the CometChat Dashboard
 
-1. Go to **CometChat Dashboard → Notification Engine → Settings → Preferences → Push Notification Preferences**.
+1. Go to **CometChat Dashboard → Notifications → Settings → Preferences → Push Notification Preferences**.
 2. Scroll to the bottom and enable the **Unread Badge Count** toggle.
 
 This ensures CometChat includes the `unreadMessageCount` field in every push payload sent to your app.

--- a/notifications/android-push-notifications.mdx
+++ b/notifications/android-push-notifications.mdx
@@ -43,7 +43,7 @@ description: "Setup FCM and CometChat for message and call push notifications on
   <img src="/images/firebase-push-notifications.png" alt="Firebase - Push Notifications" />
 </Frame>
 
-2. **CometChat dashboard**: Go to **Notifications → Settings**, enable **Push Notifications**, click **Add Credentials** (FCM), upload the Firebase service account JSON (Project settings → Service accounts → Generate new private key), and copy the Provider ID.
+2. **CometChat dashboard**: Go to **Notifications → Settings**, enable **Push Notifications**, click **Add Credentials** (FCM), enter a **Provider ID** (a unique identifier you choose), and upload the Firebase service account JSON (Project settings → Service accounts → Generate new private key).
 
 <Frame>
   <img src="/images/80a520bb-pushnotification-enable-e64632d479a2ebba111453b95bd522c6.png" alt="Enable Push Notifications" />
@@ -57,7 +57,7 @@ From the same screen, click **Add Provider** to upload the Firebase service acco
 
 3. **App constants**: 
 Note down your CometChat App ID, Auth Key, and Region from the CometChat dashboard and keep them available to be added to your project's AppCrendentials.kt. 
-Similarly, note the FCM Provider ID generated in the CometChat dashboard and add the same in your AppConstants.kt; this will be when registering the FCM token with CometChat.
+Similarly, note the FCM Provider ID you set in the CometChat dashboard and add the same in your AppConstants.kt; this will be when registering the FCM token with CometChat.
 
 ## 2. Add dependencies (Gradle)
 

--- a/notifications/flutter-push-notifications-android.mdx
+++ b/notifications/flutter-push-notifications-android.mdx
@@ -194,7 +194,7 @@ CometChat's Enhanced Push Notification payload includes an `unreadMessageCount` 
 
 ### 6.1 Enable unread badge count on the CometChat Dashboard
 
-1. Go to **CometChat Dashboard → Notification Engine → Settings → Preferences → Push Notification Preferences**.
+1. Go to **CometChat Dashboard → Notifications → Settings → Preferences → Push Notification Preferences**.
 2. Scroll to the bottom and enable the **Unread Badge Count** toggle.
 
 This ensures CometChat includes the `unreadMessageCount` field in every push payload sent to your app.

--- a/notifications/flutter-push-notifications-ios.mdx
+++ b/notifications/flutter-push-notifications-ios.mdx
@@ -227,7 +227,7 @@ If you use only APNs (no FCM on iOS), the badge is handled entirely by the serve
 
 ### 7.1 Enable unread badge count on the CometChat Dashboard
 
-1. Go to **CometChat Dashboard → Notification Engine → Settings → Preferences → Push Notification Preferences**.
+1. Go to **CometChat Dashboard → Notifications → Settings → Preferences → Push Notification Preferences**.
 2. Scroll to the bottom and enable the **Unread Badge Count** toggle.
 
 This ensures CometChat includes the `unreadMessageCount` field in every push payload (and sets `aps.badge` for APNs) sent to your app.

--- a/notifications/ios-apns-push-notifications.mdx
+++ b/notifications/ios-apns-push-notifications.mdx
@@ -1214,7 +1214,7 @@ CometChat's Enhanced Push Notification payload includes an `unreadMessageCount` 
 
 ### 6.1 Enable unread badge count on the CometChat Dashboard
 
-1. Go to **CometChat Dashboard → Notification Engine → Settings → Preferences → Push Notification Preferences**.
+1. Go to **CometChat Dashboard → Notifications → Settings → Preferences → Push Notification Preferences**.
 2. Scroll to the bottom and enable the **Unread Badge Count** toggle.
 
 This ensures CometChat includes the `unreadMessageCount` field in every push payload sent to your app.

--- a/notifications/push-overview.mdx
+++ b/notifications/push-overview.mdx
@@ -34,9 +34,9 @@ CometChat listens for chat and call events, assembles payloads from your templat
 
 ## Before you integrate
 
-1. **Dashboard setup**: In the CometChat dashboard, go to **Notifications → Settings**, enable **Push Notifications**, and click **Add Credentials** to add your providers (FCM for Android/iOS, APNs + optional APNs VoIP for iOS).
-2. **Provider ID**: Each provider you add has a **Provider ID**. Copy it — you pass it to `registerPushToken(...)` in your app so CometChat knows which credentials to use when sending a push. You can look up your Provider IDs any time under **Notifications → Settings**.
-3. **Credentials**: Keep App ID, Region, Auth Key handy. Upload the Firebase service account JSON and APNs `.p8` key (Team ID + Key ID).
+1. **Dashboard setup**: In the CometChat dashboard, go to **Notifications → Settings**, enable **Push Notifications**, and click **Add Credentials** to add a provider (FCM for Android/iOS, APNs + optional APNs VoIP for iOS). In the credential dialog, **enter a Provider ID** — a unique identifier you choose — and upload the provider key (FCM service account JSON, or the APNs `.p8` with Team ID + Key ID).
+2. **Provider ID**: The **Provider ID** you set in step 1 is required at runtime — your app passes it to `registerPushToken(...)` so CometChat knows which credentials to use when sending a push. You can look it up any time under **Notifications → Settings**.
+3. **Credentials**: Keep your App ID, Region, and Auth Key handy for initializing the SDK in your app.
 4. **Client wiring**: Register tokens after login and unregister on logout. Follow the platform guide below for Gradle/Info.plist/CallKeep specifics.
 
 ## Choose your platform

--- a/notifications/push-overview.mdx
+++ b/notifications/push-overview.mdx
@@ -29,7 +29,7 @@ CometChat listens for chat and call events, assembles payloads from your templat
 - Call invites, missed calls, and ongoing call updates.
 
 <Note>
-**Call notifications and group calls:** Call-related push notifications (e.g., initiated calls, missed calls) are sent as **custom messages**, not as group action messages. The **production mode toggle** in the dashboard only affects APNs endpoint routing (sandbox vs production) — it does not change how the Notification Engine constructs the push payload. If you experience APNs errors (e.g., 400 status) for call pushes, check your APNs provider credentials and certificate configuration rather than the production mode toggle.
+**Call notifications and group calls:** Call-related push notifications (e.g., initiated calls, missed calls) are sent as **custom messages**, not as group action messages. The **production mode toggle** in the dashboard only affects APNs endpoint routing (sandbox vs production) — it does not change how CometChat constructs the push payload. If you experience APNs errors (e.g., 400 status) for call pushes, check your APNs provider credentials and certificate configuration rather than the production mode toggle.
 </Note>
 
 ## Before you integrate

--- a/notifications/push-overview.mdx
+++ b/notifications/push-overview.mdx
@@ -34,9 +34,10 @@ CometChat listens for chat and call events, assembles payloads from your templat
 
 ## Before you integrate
 
-1. **Dashboard setup**: Enable Push Notifications, add providers (FCM for Android/iOS, APNs + optional APNs VoIP for iOS), and copy Provider IDs.
-2. **Credentials**: Keep App ID, Region, Auth Key handy. Upload the Firebase service account JSON and APNs `.p8` key (Team ID + Key ID).
-3. **Client wiring**: Register tokens after login and unregister on logout. Follow the platform guide below for Gradle/Info.plist/CallKeep specifics.
+1. **Dashboard setup**: In the CometChat dashboard, go to **Notifications → Settings**, enable **Push Notifications**, and click **Add Credentials** to add your providers (FCM for Android/iOS, APNs + optional APNs VoIP for iOS).
+2. **Provider ID**: Each provider you add has a **Provider ID**. Copy it — you pass it to `registerPushToken(...)` in your app so CometChat knows which credentials to use when sending a push. You can look up your Provider IDs any time under **Notifications → Settings**.
+3. **Credentials**: Keep App ID, Region, Auth Key handy. Upload the Firebase service account JSON and APNs `.p8` key (Team ID + Key ID).
+4. **Client wiring**: Register tokens after login and unregister on logout. Follow the platform guide below for Gradle/Info.plist/CallKeep specifics.
 
 ## Choose your platform
 


### PR DESCRIPTION
## What & why

Addresses the DOCUMENTATION_GAP from AgentBuddy ticket **#45144** (Jul 15–22), tracked as [ENG-37951](https://linear.app/cometchat/issue/ENG-37951).

### 1. Broken route: `/notifications/push-integration`
AgentBuddy agents linked users to `/notifications/push-integration`, but **no such page exists** — the path fell through to the docs home page. Added a redirect to the real push overview:

```json
{ "source": "/notifications/push-integration", "destination": "/notifications/push-overview" }
```

### 2. Provider ID setup
The push **overview** mentioned "copy Provider IDs" in passing but never explained what a Provider ID is or where it comes from. Made it explicit in **Before you integrate**:
- Dashboard path (**Notifications → Settings → Add Credentials**)
- That you **enter a Provider ID** (a unique identifier you choose) in the credential dialog
- That it's **required at runtime** and passed to `registerPushToken(...)`, and where to look it up later

### 3. Corrected "generated" wording (Android page)
`notifications/android-push-notifications.mdx` said the FCM Provider ID is "generated in the CometChat dashboard." The Add Credential dialog shows the Provider ID is a **user-entered** field, so this is corrected to "the Provider ID you set."

## Notes verified with the dashboard UI
- **"Notifications → Settings" is the right path.** The live dashboard currently shows "Notification Engine" (a label bug being renamed to "Notifications"); the wording here matches the prod-docs screenshots and the post-rename UI.
- **Provider ID is user-entered, not auto-generated** — confirmed against the Add Credential dialog (it's a text field). This resolves the earlier generated-vs-user-defined ambiguity in favor of the source ticket.

Fixes ENG-37951

🤖 Generated with [Claude Code](https://claude.com/claude-code)