### PR TITLE
docs(widget/wordpress): align integration & overview with the shipped plugin

### DIFF
--- a/widget/wordpress/integration.mdx
+++ b/widget/wordpress/integration.mdx
@@ -71,7 +71,7 @@ After registering, create a **new app** and retrieve your **authentication detai
 
   <Step title="Configure Plugin Settings">
 1. In WordPress Admin, open the **CometChat** plugin settings (added after you activate the plugin).
-2. Paste your **Widget ID**, **App ID**, **Region**, and **Auth Key**, then click **Save Changes**.
+2. Paste your **Variant ID**, **App ID**, **Region**, and **Auth Key**, then click **Save Changes**.
 
 <Note>
 **How users are authenticated:** The plugin renders the chat widget on your site's frontend only for **logged-in WordPress users** — it is gated by WordPress's `is_user_logged_in()`. For each logged-in visitor, the plugin automatically maps the WordPress user to a CometChat user (UID) and signs them in with a securely generated auth token; you do **not** configure a fixed user UID in the plugin. Where the widget appears (inline vs. floating) is set per placement by the shortcode's `docked` attribute, shown below.

--- a/widget/wordpress/integration.mdx
+++ b/widget/wordpress/integration.mdx
@@ -70,13 +70,12 @@ After registering, create a **new app** and retrieve your **authentication detai
 </Step>
 
   <Step title="Configure Plugin Settings">
-1. In WordPress Admin, go to **CometChat UI Kit Builder** in the sidebar.  
-2. Paste your **Widget ID**, **App ID**, **Region**, and **Auth Key**.  
-3. (Optional) Set **Default User UID** to auto-login a specific user.  
-4. Choose **Display Mode**:  
-   - **Embedded** (inline on specific pages)  
-   - **Docked** (floating on every page)  
-5. Click **Save Changes**.
+1. In WordPress Admin, open the **CometChat** plugin settings (added after you activate the plugin).
+2. Paste your **Widget ID**, **App ID**, **Region**, and **Auth Key**, then click **Save Changes**.
+
+<Note>
+**How users are authenticated:** The plugin renders the chat widget on your site's frontend only for **logged-in WordPress users** — it is gated by WordPress's `is_user_logged_in()`. For each logged-in visitor, the plugin automatically maps the WordPress user to a CometChat user (UID) and signs them in with a securely generated auth token; you do **not** configure a fixed user UID in the plugin. Where the widget appears (inline vs. floating) is set per placement by the shortcode's `docked` attribute, shown below.
+</Note>
   </Step>
 
   <Step title="Embed Widget Inline (Embedded Mode)">
@@ -110,9 +109,8 @@ After registering, create a **new app** and retrieve your **authentication detai
 2. Publish or update to see the widget docked on the chosen side.
   </Step>
 
-  <Step title="Enable Docked on All Pages">
-1. In **CometChat UI Kit Builder** settings, set **Display Mode** to **Docked**.  
-2. Save—widget will now float on every public page.
+  <Step title="Show the Docked Widget on Every Page">
+Add the docked shortcode (`docked="true"`) to a template that renders on every page — for example a site-wide footer, a **Custom HTML** block in a global widget area, or your theme's footer template. The floating bubble will then appear across your public pages (for logged-in WordPress users).
   </Step>
 
 </Steps>
@@ -120,6 +118,34 @@ After registering, create a **new app** and retrieve your **authentication detai
 ---
 
 <AdvancedJSAPIs />
+
+---
+
+## Anonymous & guest access
+
+Because the widget is gated by WordPress login, visitors who are **not** signed in to WordPress won't see it by default.
+
+- **Member sites:** no extra setup — your existing WordPress login is the gate, and the plugin authenticates each signed-in member automatically.
+- **Guest / anonymous chat:** provide a WordPress-side guest sign-in so the visitor becomes a logged-in WordPress user (for example, sign the visitor into a shared guest account on page load). The plugin then maps that guest to a CometChat UID and authenticates them like any other user.
+
+---
+
+## Customize the widget with CSS
+
+The Widget Builder includes a **Custom Code** tab where you can add **Custom CSS** (and Custom JS) that ships with your widget. Styling uses the same `--cometchat-*` CSS variables used across CometChat's UI Kits, so you can re-theme colors, typography, and spacing without editing the plugin.
+
+Open it from the dashboard: **Chat & Messaging → Get Started / Integrate → No Code → WordPress → Widget Builder → Custom Code** tab.
+
+Example — override the primary color and font:
+
+```css
+:root {
+  --cometchat-primary-color: #6852D6;
+  --cometchat-font-family: "Inter", sans-serif;
+}
+```
+
+Save and re-publish in the Widget Builder, then re-copy the embed code if your Variant ID changed.
 
 ---
 

--- a/widget/wordpress/integration.mdx
+++ b/widget/wordpress/integration.mdx
@@ -12,7 +12,7 @@ Go through the [Overview](https://app.cometchat.com/) to generate your Widget fr
 Ensure you have:
 - A WordPress site (5.0+)
 - PHP 7.2 or higher
-- Your **App ID**, **Region**, and **Auth Key**
+- Your **App ID**, **Region**, and **REST API Key**
 
 ## Quick Steps to Embed CometChat Widget
 
@@ -61,20 +61,24 @@ After registering, create a **new app** and retrieve your **authentication detai
 
 1. Navigate to **Application**, then select the **Credentials** section.
 
-2. Note down the following keys:
+2. Note down the following:
 
    * **App ID**
-   * **Auth Key**
    * **Region**
+   * **REST API Key** (from **Credentials → REST API Keys**)
 
 </Step>
 
   <Step title="Configure Plugin Settings">
-1. In WordPress Admin, open the **CometChat** plugin settings (added after you activate the plugin).
-2. Paste your **Variant ID**, **App ID**, **Region**, and **Auth Key**, then click **Save Changes**.
+1. In WordPress Admin, go to **Settings → CometChat** (or click **Settings** on the CometChat row under **Plugins**).
+2. Fill in:
+   - **App ID** and **App Region** — from **Dashboard → App → Credentials**.
+   - **API Version** — select **3**. Leaving this unset falls back to the legacy v2 API and user creation will fail.
+   - **REST API Key** — from **Dashboard → App → Credentials → REST API Keys**. This is the REST API key, not the Auth Key.
+3. Click **Update Settings**.
 
 <Note>
-**How users are authenticated:** The plugin renders the chat widget on your site's frontend only for **logged-in WordPress users** — it is gated by WordPress's `is_user_logged_in()`. For each logged-in visitor, the plugin automatically maps the WordPress user to a CometChat user (UID) and signs them in with a securely generated auth token; you do **not** configure a fixed user UID in the plugin. Where the widget appears (inline vs. floating) is set per placement by the shortcode's `docked` attribute, shown below.
+**How users are authenticated:** The plugin renders the chat widget on your site's frontend only for **logged-in WordPress users** — it is gated by WordPress's `is_user_logged_in()`. For each logged-in visitor, the plugin automatically maps the WordPress user to a CometChat user whose **UID is the WordPress numeric user ID** and signs them in with a securely generated auth token; you do **not** configure a fixed user UID in the plugin. Logged-out visitors don't see the widget — the shortcode renders the literal text *"Please login to use this feature."* instead. Where the widget appears (inline vs. floating) is set per placement by the shortcode's `docked` attribute, shown below.
 </Note>
   </Step>
 
@@ -110,7 +114,11 @@ After registering, create a **new app** and retrieve your **authentication detai
   </Step>
 
   <Step title="Show the Docked Widget on Every Page">
-Add the docked shortcode (`docked="true"`) to a template that renders on every page — for example a site-wide footer, a **Custom HTML** block in a global widget area, or your theme's footer template. The floating bubble will then appear across your public pages (for logged-in WordPress users).
+In **Settings → CometChat**, paste your docked shortcode (`docked="true"`) into the **"Load CometChat on all pages/sitewide?"** field and click **Update Settings**. The plugin then renders the widget in the footer of every page for logged-in WordPress users.
+
+<Note>
+For logged-out visitors, a sitewide shortcode prints *"Please login to use this feature."* on every page. Leave the field blank or hide `#cometchat` via CSS if that isn't wanted.
+</Note>
   </Step>
 
 </Steps>
@@ -123,10 +131,10 @@ Add the docked shortcode (`docked="true"`) to a template that renders on every p
 
 ## Anonymous & guest access
 
-Because the widget is gated by WordPress login, visitors who are **not** signed in to WordPress won't see it by default.
+Because the widget is gated by WordPress login, visitors who are **not** signed in to WordPress won't see it — the shortcode only renders for logged-in WordPress users.
 
 - **Member sites:** no extra setup — your existing WordPress login is the gate, and the plugin authenticates each signed-in member automatically.
-- **Guest / anonymous chat:** provide a WordPress-side guest sign-in so the visitor becomes a logged-in WordPress user (for example, sign the visitor into a shared guest account on page load). The plugin then maps that guest to a CometChat UID and authenticates them like any other user.
+- **Guest / anonymous chat:** not supported by the WordPress plugin. If you need anonymous chat, use the [HTML/JS embed](/widget/html/overview) with `mode: "guest"` on those pages instead of the plugin shortcode.
 
 ---
 
@@ -136,10 +144,12 @@ The Widget Builder includes a **Custom Code** tab where you can add **Custom CSS
 
 Open it from the dashboard: **Chat & Messaging → Get Started / Integrate → No Code → WordPress → Widget Builder → Custom Code** tab.
 
+Custom CSS added here is automatically scoped under the widget's root, so top-level selectors like `:root` or `body` won't match. Target **`.cometchat-root`** — which carries the `--cometchat-*` variables — instead.
+
 Example — override the primary color and font:
 
 ```css
-:root {
+.cometchat-root {
   --cometchat-primary-color: #6852D6;
   --cometchat-font-family: "Inter", sans-serif;
 }

--- a/widget/wordpress/overview.mdx
+++ b/widget/wordpress/overview.mdx
@@ -58,7 +58,7 @@ Customize your chat widget using the visual Widget Builder:
 Once configured, get the embed code snippet for your widget.
 
 1. Click on **Get Embed Code**
-2. Note your app credentials (App ID, Auth Key, Region, Variant ID)
+2. Note your app credentials (App ID, Region, REST API Key, Variant ID)
 3. Copy the code snippet
 
 ### 3. Integrate
@@ -66,7 +66,7 @@ Once configured, get the embed code snippet for your widget.
 Install the CometChat plugin on your WordPress site and go live.
 
 1. **Install the plugin** — Download and activate the CometChat WordPress plugin
-2. **Configure credentials** — Set your App ID, Region, and Auth Key in the plugin settings
+2. **Configure credentials** — Set your App ID, Region, API Version, and REST API Key in the plugin settings
 3. **User Authentication** — CometChat uses a UID (User ID) to identify each user. Authenticate users to enable chat functionality.
 4. **Launch** — Use shortcodes or the plugin settings to display the chat widget on your site
 

--- a/widget/wordpress/overview.mdx
+++ b/widget/wordpress/overview.mdx
@@ -57,7 +57,7 @@ Customize your chat widget using the visual Widget Builder:
 
 Once configured, get the embed code snippet for your widget.
 
-1. Click on **Get Embedded Code**
+1. Click on **Get Embed Code**
 2. Note your app credentials (App ID, Auth Key, Region, Variant ID)
 3. Copy the code snippet
 
@@ -77,6 +77,12 @@ Install the CometChat plugin on your WordPress site and go live.
 >
   Step-by-step instructions for embedding the Widget Builder into your WordPress website
 </Card>
+
+---
+
+## Customization
+
+The Widget Builder controls theme, colors, and typography with no code. For deeper control, open the Widget Builder's **Custom Code** tab and add your own **Custom CSS** (and Custom JS) using the `--cometchat-*` CSS variables — the same variables used across CometChat's UI Kits. See [Customize the widget with CSS](/widget/wordpress/integration#customize-the-widget-with-css) in the Integration guide.
 
 ---
 


### PR DESCRIPTION
## What & why

Addresses [ENG-37952](https://linear.app/cometchat/issue/ENG-37952) (AgentBuddy DOCUMENTATION_GAP, ticket **#45163**, appears in both the Jul 15–22 and Jul 21–28 tabs). The WordPress widget docs described a plugin UI that doesn't match what ships, which led an AI agent to answer a support ticket incorrectly end-to-end.

## Changes

**`integration.mdx`**
- **Removed** the non-existent **"CometChat UI Kit Builder"** sidebar item, **"Default User UID"** field, and plugin-level **"Display Mode"** setting from *Configure Plugin Settings*.
- **Documented the real auth model**: the widget is gated by WordPress's `is_user_logged_in()`, and the plugin auto-maps each logged-in WP user to a CometChat UID with a securely generated auth token (no fixed UID in the plugin).
- **Docked vs. embedded** is driven by the shortcode `docked` attribute; reworked the "every page" step to use the shortcode instead of a Display Mode setting.
- Added **Anonymous & guest access** guidance and a **Customize the widget with CSS** section (Widget Builder → Custom Code tab, `--cometchat-*` variables) with the correct dashboard nav path.

**`overview.mdx`**
- Fixed button label **"Get Embedded Code" → "Get Embed Code"**.
- Added a short **Customization** pointer to the new CSS section.

## ⚠️ Reviewer verification needed (treated the L2/sheet findings as source of truth)
I don't have the shipped plugin source, so please confirm these before merge:
1. **Real plugin settings location/label** — I replaced "CometChat UI Kit Builder in the sidebar" with a neutral "open the **CometChat** plugin settings." Please set the exact WP admin menu label.
2. **`is_user_logged_in()` gate + auto UID mapping + auto auth-token** — stated per L2; confirm wording matches plugin behavior.
3. **Guest access recipe** — described at a high level (WP-side guest sign-in); confirm the recommended approach.
4. **"Get Embed Code" label** — the old "Get Embed**ded** Code" string is still used in **12 other files** (all other widget platforms + `snippets/widget/overview.mdx` + several `ai-agents/*` pages). If the real button is "Get Embed Code", those should be updated in a follow-up; I scoped this PR to the WordPress ticket only.
5. **`--cometchat-*` example values** — the two variables shown are illustrative; confirm the canonical widget theming variables.

Fixes ENG-37952

🤖 Generated with [Claude Code](https://claude.com/claude-code)