### PR TITLE
[A/B — do not merge] Flatten Voice & Video nav to test version-tree 500

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -5348,585 +5348,580 @@
             ]
           },
           {
-            "tab": "SDK",
-            "dropdowns": [
+            "tab": "JavaScript",
+            "icon": "/images/icons/js.svg",
+            "versions": [
               {
-                "dropdown": "JavaScript",
-                "icon": "/images/icons/js.svg",
-                "versions": [
+                "version": "v5",
+                "groups": [
                   {
-                    "version": "v5",
-                    "groups": [
-                      {
-                        "group": "Overview",
-                        "pages": [
-                          "calls/javascript/overview"
-                        ]
-                      },
-                      {
-                        "group": "Integrations",
-                        "pages": [
-                          "calls/javascript/react-integration",
-                          "calls/javascript/vue-integration",
-                          "calls/javascript/angular-integration",
-                          "calls/javascript/nextjs-integration",
-                          "calls/javascript/ionic-integration"
-                        ]
-                      },
-                      {
-                        "group": "Getting Started",
-                        "pages": [
-                          "calls/javascript/setup",
-                          "calls/javascript/authentication"
-                        ]
-                      },
-                      {
-                        "group": "Call Session",
-                        "pages": [
-                          "calls/javascript/session-settings",
-                          "calls/javascript/join-session",
-                          "calls/javascript/actions",
-                          "calls/javascript/events"
-                        ]
-                      },
-                      {
-                        "group": "Features",
-                        "pages": [
-                          "calls/javascript/ringing",
-                          "calls/javascript/call-layouts",
-                          "calls/javascript/recording",
-                          "calls/javascript/call-logs",
-                          "calls/javascript/participant-management",
-                          "calls/javascript/screen-sharing",
-                          "calls/javascript/virtual-background",
-                          "calls/javascript/raise-hand",
-                          "calls/javascript/idle-timeout"
-                        ]
-                      },
-                      {
-                        "group": "Advanced",
-                        "pages": [
-                          "calls/javascript/custom-control-panel",
-                          "calls/javascript/device-management",
-                          "calls/javascript/permissions-handling",
-                          "calls/javascript/in-call-chat",
-                          "calls/javascript/share-invite"
-                        ]
-                      },
-                      {
-                        "group": "Migration Guide",
-                        "pages": [
-                          "calls/javascript/migration-guide-v5"
-                        ]
-                      },
-                      {
-                        "group": "Resources",
-                        "pages": [
-                          "calls/javascript/troubleshooting",
-                          "calls/javascript/link/github",
-                          "calls/javascript/link/sample-apps",
-                          "calls/javascript/link/changelog",
-                          "calls/javascript/link/live-demo"
-                        ]
-                      }
+                    "group": "Overview",
+                    "pages": [
+                      "calls/javascript/overview"
                     ]
                   },
                   {
-                    "version": "v4",
-                    "groups": [
-                      {
-                        "group": " ",
-                        "pages": [
-                          "calls/v4/javascript/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/javascript/setup"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/javascript/ringing",
-                              "calls/v4/javascript/call-session",
-                              "calls/v4/javascript/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/javascript/recording",
-                              "calls/v4/javascript/call-logs",
-                              "calls/v4/javascript/session-timeout"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/javascript/video-view-customisation",
-                              "calls/v4/javascript/presenter-mode",
-                              "calls/v4/javascript/virtual-background",
-                              "calls/v4/javascript/custom-css"
-                            ]
-                          }
-                        ]
-                      }
+                    "group": "Integrations",
+                    "pages": [
+                      "calls/javascript/react-integration",
+                      "calls/javascript/vue-integration",
+                      "calls/javascript/angular-integration",
+                      "calls/javascript/nextjs-integration",
+                      "calls/javascript/ionic-integration"
+                    ]
+                  },
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "calls/javascript/setup",
+                      "calls/javascript/authentication"
+                    ]
+                  },
+                  {
+                    "group": "Call Session",
+                    "pages": [
+                      "calls/javascript/session-settings",
+                      "calls/javascript/join-session",
+                      "calls/javascript/actions",
+                      "calls/javascript/events"
+                    ]
+                  },
+                  {
+                    "group": "Features",
+                    "pages": [
+                      "calls/javascript/ringing",
+                      "calls/javascript/call-layouts",
+                      "calls/javascript/recording",
+                      "calls/javascript/call-logs",
+                      "calls/javascript/participant-management",
+                      "calls/javascript/screen-sharing",
+                      "calls/javascript/virtual-background",
+                      "calls/javascript/raise-hand",
+                      "calls/javascript/idle-timeout"
+                    ]
+                  },
+                  {
+                    "group": "Advanced",
+                    "pages": [
+                      "calls/javascript/custom-control-panel",
+                      "calls/javascript/device-management",
+                      "calls/javascript/permissions-handling",
+                      "calls/javascript/in-call-chat",
+                      "calls/javascript/share-invite"
+                    ]
+                  },
+                  {
+                    "group": "Migration Guide",
+                    "pages": [
+                      "calls/javascript/migration-guide-v5"
+                    ]
+                  },
+                  {
+                    "group": "Resources",
+                    "pages": [
+                      "calls/javascript/troubleshooting",
+                      "calls/javascript/link/github",
+                      "calls/javascript/link/sample-apps",
+                      "calls/javascript/link/changelog",
+                      "calls/javascript/link/live-demo"
                     ]
                   }
                 ]
               },
               {
-                "dropdown": "React Native",
-                "icon": "/images/icons/react.svg",
-                "versions": [
+                "version": "v4",
+                "groups": [
                   {
-                    "version": "v5",
-                    "groups": [
-                      {
-                        "group": "Overview",
-                        "pages": [
-                          "calls/react-native/overview"
-                        ]
-                      },
+                    "group": " ",
+                    "pages": [
+                      "calls/v4/javascript/overview",
                       {
                         "group": "Getting Started",
                         "pages": [
-                          "calls/react-native/setup",
-                          "calls/react-native/authentication",
-                          "calls/react-native/session-settings"
+                          "calls/v4/javascript/setup"
                         ]
                       },
                       {
-                        "group": "Call Session",
+                        "group": "Calling Flows",
                         "pages": [
-                          "calls/react-native/join-session",
-                          "calls/react-native/actions",
-                          "calls/react-native/events"
+                          "calls/v4/javascript/ringing",
+                          "calls/v4/javascript/call-session",
+                          "calls/v4/javascript/standalone-calling"
                         ]
                       },
                       {
                         "group": "Features",
                         "pages": [
-                          "calls/react-native/call-layouts",
-                          "calls/react-native/call-logs",
-                          "calls/react-native/recording",
-                          "calls/react-native/participant-management",
-                          "calls/react-native/screen-sharing",
-                          "calls/react-native/audio-modes",
-                          "calls/react-native/raise-hand",
-                          "calls/react-native/idle-timeout",
-                          "calls/react-native/ringing"
+                          "calls/v4/javascript/recording",
+                          "calls/v4/javascript/call-logs",
+                          "calls/v4/javascript/session-timeout"
                         ]
                       },
                       {
-                        "group": "Advanced",
+                        "group": "Customisation",
                         "pages": [
-                          "calls/react-native/picture-in-picture",
-                          "calls/react-native/voip-calling",
-                          "calls/react-native/background-handling",
-                          "calls/react-native/custom-control-panel",
-                          "calls/react-native/custom-participant-list",
-                          "calls/react-native/in-call-chat",
-                          "calls/react-native/share-invite"
-                        ]
-                      },
-                      {
-                        "group": "Migration Guide",
-                        "pages": [
-                          "calls/react-native/migration-guide-v5"
-                        ]
-                      },
-                      {
-                        "group": "Resources",
-                        "pages": [
-                          "calls/react-native/troubleshooting",
-                          "calls/react-native/link/github",
-                          "calls/react-native/link/sample-apps",
-                          "calls/react-native/link/changelog"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "version": "v4",
-                    "groups": [
-                      {
-                        "group": " ",
-                        "pages": [
-                          "calls/v4/react-native/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/react-native/setup",
-                              "calls/v4/react-native/expo-integration-guide"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/react-native/ringing",
-                              "calls/v4/react-native/call-session",
-                              "calls/v4/react-native/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/react-native/recording",
-                              "calls/v4/react-native/call-logs",
-                              "calls/v4/react-native/session-timeout"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/react-native/video-view-customisation",
-                              "calls/v4/react-native/presenter-mode"
-                            ]
-                          }
+                          "calls/v4/javascript/video-view-customisation",
+                          "calls/v4/javascript/presenter-mode",
+                          "calls/v4/javascript/virtual-background",
+                          "calls/v4/javascript/custom-css"
                         ]
                       }
                     ]
                   }
                 ]
-              },
+              }
+            ]
+          },
+          {
+            "tab": "React Native",
+            "icon": "/images/icons/react.svg",
+            "versions": [
               {
-                "dropdown": "iOS",
-                "icon": "/images/icons/swift.svg",
-                "versions": [
+                "version": "v5",
+                "groups": [
                   {
-                    "version": "v5",
-                    "groups": [
-                      {
-                        "group": "Overview",
-                        "pages": [
-                          "calls/ios/overview"
-                        ]
-                      },
-                      {
-                        "group": "Getting Started",
-                        "pages": [
-                          "calls/ios/setup",
-                          "calls/ios/authentication"
-                        ]
-                      },
-                      {
-                        "group": "Call Session",
-                        "pages": [
-                          "calls/ios/session-settings",
-                          "calls/ios/join-session",
-                          "calls/ios/actions",
-                          "calls/ios/events"
-                        ]
-                      },
-                      {
-                        "group": "Features",
-                        "pages": [
-                          "calls/ios/ringing",
-                          "calls/ios/call-layouts",
-                          "calls/ios/audio-modes",
-                          "calls/ios/recording",
-                          "calls/ios/call-logs",
-                          "calls/ios/participant-management",
-                          "calls/ios/screen-sharing",
-                          "calls/ios/picture-in-picture",
-                          "calls/ios/raise-hand",
-                          "calls/ios/idle-timeout"
-                        ]
-                      },
-                      {
-                        "group": "Advanced",
-                        "pages": [
-                          "calls/ios/custom-control-panel",
-                          "calls/ios/custom-participant-list",
-                          "calls/ios/voip-calling",
-                          "calls/ios/background-handling",
-                          "calls/ios/in-call-chat",
-                          "calls/ios/share-invite"
-                        ]
-                      },
-                      {
-                        "group": "Migration Guide",
-                        "pages": [
-                          "calls/ios/migration-guide-v5"
-                        ]
-                      },
-                      {
-                        "group": "Resources",
-                        "pages": [
-                          "calls/ios/troubleshooting",
-                          "calls/ios/link/github",
-                          "calls/ios/link/sample-apps",
-                          "calls/ios/link/changelog"
-                        ]
-                      }
+                    "group": "Overview",
+                    "pages": [
+                      "calls/react-native/overview"
                     ]
                   },
                   {
-                    "version": "v4",
-                    "groups": [
-                      {
-                        "group": " ",
-                        "pages": [
-                          "calls/v4/ios/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/ios/setup"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/ios/ringing",
-                              "calls/v4/ios/call-session",
-                              "calls/v4/ios/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/ios/recording",
-                              "calls/v4/ios/call-logs",
-                              "calls/v4/ios/session-timeout",
-                              "calls/v4/ios/launch-call-screen-on-tap-of-push-notification"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/ios/video-view-customisation",
-                              "calls/v4/ios/presenter-mode"
-                            ]
-                          }
-                        ]
-                      }
+                    "group": "Getting Started",
+                    "pages": [
+                      "calls/react-native/setup",
+                      "calls/react-native/authentication",
+                      "calls/react-native/session-settings"
+                    ]
+                  },
+                  {
+                    "group": "Call Session",
+                    "pages": [
+                      "calls/react-native/join-session",
+                      "calls/react-native/actions",
+                      "calls/react-native/events"
+                    ]
+                  },
+                  {
+                    "group": "Features",
+                    "pages": [
+                      "calls/react-native/call-layouts",
+                      "calls/react-native/call-logs",
+                      "calls/react-native/recording",
+                      "calls/react-native/participant-management",
+                      "calls/react-native/screen-sharing",
+                      "calls/react-native/audio-modes",
+                      "calls/react-native/raise-hand",
+                      "calls/react-native/idle-timeout",
+                      "calls/react-native/ringing"
+                    ]
+                  },
+                  {
+                    "group": "Advanced",
+                    "pages": [
+                      "calls/react-native/picture-in-picture",
+                      "calls/react-native/voip-calling",
+                      "calls/react-native/background-handling",
+                      "calls/react-native/custom-control-panel",
+                      "calls/react-native/custom-participant-list",
+                      "calls/react-native/in-call-chat",
+                      "calls/react-native/share-invite"
+                    ]
+                  },
+                  {
+                    "group": "Migration Guide",
+                    "pages": [
+                      "calls/react-native/migration-guide-v5"
+                    ]
+                  },
+                  {
+                    "group": "Resources",
+                    "pages": [
+                      "calls/react-native/troubleshooting",
+                      "calls/react-native/link/github",
+                      "calls/react-native/link/sample-apps",
+                      "calls/react-native/link/changelog"
                     ]
                   }
                 ]
               },
               {
-                "dropdown": "Android",
-                "icon": "/images/icons/android.svg",
-                "versions": [
+                "version": "v4",
+                "groups": [
                   {
-                    "version": "v5",
-                    "groups": [
-                      {
-                        "group": "Overview",
-                        "pages": [
-                          "calls/android/overview"
-                        ]
-                      },
+                    "group": " ",
+                    "pages": [
+                      "calls/v4/react-native/overview",
                       {
                         "group": "Getting Started",
                         "pages": [
-                          "calls/android/setup",
-                          "calls/android/authentication"
+                          "calls/v4/react-native/setup",
+                          "calls/v4/react-native/expo-integration-guide"
                         ]
                       },
                       {
-                        "group": "Call Session",
+                        "group": "Calling Flows",
                         "pages": [
-                          "calls/android/session-settings",
-                          "calls/android/join-session",
-                          "calls/android/actions",
-                          "calls/android/events"
+                          "calls/v4/react-native/ringing",
+                          "calls/v4/react-native/call-session",
+                          "calls/v4/react-native/standalone-calling"
                         ]
                       },
                       {
                         "group": "Features",
                         "pages": [
-                          "calls/android/ringing",
-                          "calls/android/call-layouts",
-                          "calls/android/audio-modes",
-                          "calls/android/recording",
-                          "calls/android/call-logs",
-                          "calls/android/participant-management",
-                          "calls/android/screen-sharing",
-                          "calls/android/picture-in-picture",
-                          "calls/android/raise-hand",
-                          "calls/android/idle-timeout"
+                          "calls/v4/react-native/recording",
+                          "calls/v4/react-native/call-logs",
+                          "calls/v4/react-native/session-timeout"
                         ]
                       },
                       {
-                        "group": "Advanced",
+                        "group": "Customisation",
                         "pages": [
-                          "calls/android/custom-control-panel",
-                          "calls/android/custom-participant-list",
-                          "calls/android/voip-calling",
-                          "calls/android/background-handling",
-                          "calls/android/in-call-chat",
-                          "calls/android/share-invite"
-                        ]
-                      },
-                      {
-                        "group": "Migration Guide",
-                        "pages": [
-                          "calls/android/migration-guide-v5"
-                        ]
-                      },
-                      {
-                        "group": "Resources",
-                        "pages": [
-                          "calls/android/troubleshooting",
-                          "calls/android/link/github",
-                          "calls/android/link/sample-apps",
-                          "calls/android/link/changelog"
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "version": "v4",
-                    "groups": [
-                      {
-                        "group": " ",
-                        "pages": [
-                          "calls/v4/android/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/android/setup"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/android/ringing",
-                              "calls/v4/android/call-session",
-                              "calls/v4/android/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/android/recording",
-                              "calls/v4/android/call-logs",
-                              "calls/v4/android/session-timeout"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/android/video-view-customisation",
-                              "calls/v4/android/presenter-mode"
-                            ]
-                          }
+                          "calls/v4/react-native/video-view-customisation",
+                          "calls/v4/react-native/presenter-mode"
                         ]
                       }
                     ]
                   }
                 ]
+              }
+            ]
+          },
+          {
+            "tab": "iOS",
+            "icon": "/images/icons/swift.svg",
+            "versions": [
+              {
+                "version": "v5",
+                "groups": [
+                  {
+                    "group": "Overview",
+                    "pages": [
+                      "calls/ios/overview"
+                    ]
+                  },
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "calls/ios/setup",
+                      "calls/ios/authentication"
+                    ]
+                  },
+                  {
+                    "group": "Call Session",
+                    "pages": [
+                      "calls/ios/session-settings",
+                      "calls/ios/join-session",
+                      "calls/ios/actions",
+                      "calls/ios/events"
+                    ]
+                  },
+                  {
+                    "group": "Features",
+                    "pages": [
+                      "calls/ios/ringing",
+                      "calls/ios/call-layouts",
+                      "calls/ios/audio-modes",
+                      "calls/ios/recording",
+                      "calls/ios/call-logs",
+                      "calls/ios/participant-management",
+                      "calls/ios/screen-sharing",
+                      "calls/ios/picture-in-picture",
+                      "calls/ios/raise-hand",
+                      "calls/ios/idle-timeout"
+                    ]
+                  },
+                  {
+                    "group": "Advanced",
+                    "pages": [
+                      "calls/ios/custom-control-panel",
+                      "calls/ios/custom-participant-list",
+                      "calls/ios/voip-calling",
+                      "calls/ios/background-handling",
+                      "calls/ios/in-call-chat",
+                      "calls/ios/share-invite"
+                    ]
+                  },
+                  {
+                    "group": "Migration Guide",
+                    "pages": [
+                      "calls/ios/migration-guide-v5"
+                    ]
+                  },
+                  {
+                    "group": "Resources",
+                    "pages": [
+                      "calls/ios/troubleshooting",
+                      "calls/ios/link/github",
+                      "calls/ios/link/sample-apps",
+                      "calls/ios/link/changelog"
+                    ]
+                  }
+                ]
               },
               {
-                "dropdown": "Flutter",
-                "icon": "/images/icons/flutter.svg",
-                "versions": [
+                "version": "v4",
+                "groups": [
                   {
-                    "version": "v5",
-                    "groups": [
-                      {
-                        "group": "Overview",
-                        "pages": [
-                          "calls/flutter/overview"
-                        ]
-                      },
+                    "group": " ",
+                    "pages": [
+                      "calls/v4/ios/overview",
                       {
                         "group": "Getting Started",
                         "pages": [
-                          "calls/flutter/setup",
-                          "calls/flutter/authentication"
+                          "calls/v4/ios/setup"
                         ]
                       },
                       {
-                        "group": "Call Session",
+                        "group": "Calling Flows",
                         "pages": [
-                          "calls/flutter/session-settings",
-                          "calls/flutter/join-session",
-                          "calls/flutter/actions",
-                          "calls/flutter/events"
+                          "calls/v4/ios/ringing",
+                          "calls/v4/ios/call-session",
+                          "calls/v4/ios/standalone-calling"
                         ]
                       },
                       {
                         "group": "Features",
                         "pages": [
-                          "calls/flutter/ringing",
-                          "calls/flutter/call-layouts",
-                          "calls/flutter/audio-modes",
-                          "calls/flutter/recording",
-                          "calls/flutter/call-logs",
-                          "calls/flutter/participant-management",
-                          "calls/flutter/screen-sharing",
-                          "calls/flutter/picture-in-picture",
-                          "calls/flutter/raise-hand",
-                          "calls/flutter/idle-timeout"
+                          "calls/v4/ios/recording",
+                          "calls/v4/ios/call-logs",
+                          "calls/v4/ios/session-timeout",
+                          "calls/v4/ios/launch-call-screen-on-tap-of-push-notification"
                         ]
                       },
                       {
-                        "group": "Advanced",
+                        "group": "Customisation",
                         "pages": [
-                          "calls/flutter/custom-control-panel",
-                          "calls/flutter/custom-participant-list",
-                          "calls/flutter/voip-calling",
-                          "calls/flutter/background-handling",
-                          "calls/flutter/in-call-chat",
-                          "calls/flutter/share-invite"
-                        ]
-                      },
-                      {
-                        "group": "Migration Guide",
-                        "pages": [
-                          "calls/flutter/migration-guide-v5"
-                        ]
-                      },
-                      {
-                        "group": "Resources",
-                        "pages": [
-                          "calls/flutter/troubleshooting",
-                          "calls/flutter/link/github",
-                          "calls/flutter/link/sample-apps",
-                          "calls/flutter/link/changelog"
+                          "calls/v4/ios/video-view-customisation",
+                          "calls/v4/ios/presenter-mode"
                         ]
                       }
                     ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Android",
+            "icon": "/images/icons/android.svg",
+            "versions": [
+              {
+                "version": "v5",
+                "groups": [
+                  {
+                    "group": "Overview",
+                    "pages": [
+                      "calls/android/overview"
+                    ]
                   },
                   {
-                    "version": "v4",
-                    "groups": [
+                    "group": "Getting Started",
+                    "pages": [
+                      "calls/android/setup",
+                      "calls/android/authentication"
+                    ]
+                  },
+                  {
+                    "group": "Call Session",
+                    "pages": [
+                      "calls/android/session-settings",
+                      "calls/android/join-session",
+                      "calls/android/actions",
+                      "calls/android/events"
+                    ]
+                  },
+                  {
+                    "group": "Features",
+                    "pages": [
+                      "calls/android/ringing",
+                      "calls/android/call-layouts",
+                      "calls/android/audio-modes",
+                      "calls/android/recording",
+                      "calls/android/call-logs",
+                      "calls/android/participant-management",
+                      "calls/android/screen-sharing",
+                      "calls/android/picture-in-picture",
+                      "calls/android/raise-hand",
+                      "calls/android/idle-timeout"
+                    ]
+                  },
+                  {
+                    "group": "Advanced",
+                    "pages": [
+                      "calls/android/custom-control-panel",
+                      "calls/android/custom-participant-list",
+                      "calls/android/voip-calling",
+                      "calls/android/background-handling",
+                      "calls/android/in-call-chat",
+                      "calls/android/share-invite"
+                    ]
+                  },
+                  {
+                    "group": "Migration Guide",
+                    "pages": [
+                      "calls/android/migration-guide-v5"
+                    ]
+                  },
+                  {
+                    "group": "Resources",
+                    "pages": [
+                      "calls/android/troubleshooting",
+                      "calls/android/link/github",
+                      "calls/android/link/sample-apps",
+                      "calls/android/link/changelog"
+                    ]
+                  }
+                ]
+              },
+              {
+                "version": "v4",
+                "groups": [
+                  {
+                    "group": " ",
+                    "pages": [
+                      "calls/v4/android/overview",
                       {
-                        "group": " ",
+                        "group": "Getting Started",
                         "pages": [
-                          "calls/v4/flutter/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/flutter/setup"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/flutter/ringing",
-                              "calls/v4/flutter/call-session",
-                              "calls/v4/flutter/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/flutter/recording",
-                              "calls/v4/flutter/call-logs",
-                              "calls/v4/flutter/session-timeout"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/flutter/video-view-customisation",
-                              "calls/v4/flutter/presenter-mode"
-                            ]
-                          }
+                          "calls/v4/android/setup"
+                        ]
+                      },
+                      {
+                        "group": "Calling Flows",
+                        "pages": [
+                          "calls/v4/android/ringing",
+                          "calls/v4/android/call-session",
+                          "calls/v4/android/standalone-calling"
+                        ]
+                      },
+                      {
+                        "group": "Features",
+                        "pages": [
+                          "calls/v4/android/recording",
+                          "calls/v4/android/call-logs",
+                          "calls/v4/android/session-timeout"
+                        ]
+                      },
+                      {
+                        "group": "Customisation",
+                        "pages": [
+                          "calls/v4/android/video-view-customisation",
+                          "calls/v4/android/presenter-mode"
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "tab": "Flutter",
+            "icon": "/images/icons/flutter.svg",
+            "versions": [
+              {
+                "version": "v5",
+                "groups": [
+                  {
+                    "group": "Overview",
+                    "pages": [
+                      "calls/flutter/overview"
+                    ]
+                  },
+                  {
+                    "group": "Getting Started",
+                    "pages": [
+                      "calls/flutter/setup",
+                      "calls/flutter/authentication"
+                    ]
+                  },
+                  {
+                    "group": "Call Session",
+                    "pages": [
+                      "calls/flutter/session-settings",
+                      "calls/flutter/join-session",
+                      "calls/flutter/actions",
+                      "calls/flutter/events"
+                    ]
+                  },
+                  {
+                    "group": "Features",
+                    "pages": [
+                      "calls/flutter/ringing",
+                      "calls/flutter/call-layouts",
+                      "calls/flutter/audio-modes",
+                      "calls/flutter/recording",
+                      "calls/flutter/call-logs",
+                      "calls/flutter/participant-management",
+                      "calls/flutter/screen-sharing",
+                      "calls/flutter/picture-in-picture",
+                      "calls/flutter/raise-hand",
+                      "calls/flutter/idle-timeout"
+                    ]
+                  },
+                  {
+                    "group": "Advanced",
+                    "pages": [
+                      "calls/flutter/custom-control-panel",
+                      "calls/flutter/custom-participant-list",
+                      "calls/flutter/voip-calling",
+                      "calls/flutter/background-handling",
+                      "calls/flutter/in-call-chat",
+                      "calls/flutter/share-invite"
+                    ]
+                  },
+                  {
+                    "group": "Migration Guide",
+                    "pages": [
+                      "calls/flutter/migration-guide-v5"
+                    ]
+                  },
+                  {
+                    "group": "Resources",
+                    "pages": [
+                      "calls/flutter/troubleshooting",
+                      "calls/flutter/link/github",
+                      "calls/flutter/link/sample-apps",
+                      "calls/flutter/link/changelog"
+                    ]
+                  }
+                ]
+              },
+              {
+                "version": "v4",
+                "groups": [
+                  {
+                    "group": " ",
+                    "pages": [
+                      "calls/v4/flutter/overview",
+                      {
+                        "group": "Getting Started",
+                        "pages": [
+                          "calls/v4/flutter/setup"
+                        ]
+                      },
+                      {
+                        "group": "Calling Flows",
+                        "pages": [
+                          "calls/v4/flutter/ringing",
+                          "calls/v4/flutter/call-session",
+                          "calls/v4/flutter/standalone-calling"
+                        ]
+                      },
+                      {
+                        "group": "Features",
+                        "pages": [
+                          "calls/v4/flutter/recording",
+                          "calls/v4/flutter/call-logs",
+                          "calls/v4/flutter/session-timeout"
+                        ]
+                      },
+                      {
+                        "group": "Customisation",
+                        "pages": [
+                          "calls/v4/flutter/video-view-customisation",
+                          "calls/v4/flutter/presenter-mode"
                         ]
                       }
                     ]

--- a/docs.json
+++ b/docs.json
@@ -1111,7 +1111,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v5‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -1228,7 +1228,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -1391,7 +1391,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -1413,7 +1413,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -1441,7 +1441,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -1550,7 +1550,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -1714,7 +1714,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -1736,7 +1736,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -1764,7 +1764,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v6‎‎‎",
+                    "version": "v6",
                     "groups": [
                       {
                         "group": " ",
@@ -1883,7 +1883,7 @@
                     ]
                   },
                   {
-                    "version": "v5‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2000,7 +2000,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -2157,7 +2157,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -2182,7 +2182,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -2211,7 +2211,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v6‎‎‎‎",
+                    "version": "v6",
                     "groups": [
                       {
                         "group": " ",
@@ -2327,7 +2327,7 @@
                     ]
                   },
                   {
-                    "version": "v5‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2431,7 +2431,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -2607,7 +2607,7 @@
                 "icon": "/images/icons/angular.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2823,7 +2823,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3013,7 +3013,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3034,7 +3034,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3061,7 +3061,7 @@
                 "icon": "/images/icons/vuejs.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3154,7 +3154,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3176,7 +3176,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3208,7 +3208,7 @@
                 "icon": "/images/icons/js.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3304,7 +3304,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3427,7 +3427,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3530,7 +3530,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3613,7 +3613,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3727,7 +3727,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3829,7 +3829,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3919,7 +3919,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -4037,7 +4037,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -4144,7 +4144,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -4246,7 +4246,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -4340,7 +4340,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -4460,7 +4460,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -4563,7 +4563,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -4655,7 +4655,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -4747,7 +4747,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -5355,7 +5355,7 @@
                 "icon": "/images/icons/js.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5432,7 +5432,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5480,7 +5480,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5548,7 +5548,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5595,7 +5595,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5663,7 +5663,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5710,7 +5710,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5778,7 +5778,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5824,7 +5824,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5892,7 +5892,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",


### PR DESCRIPTION
## Purpose — A/B test only, NOT for merge (base retargeted to `main` so Mintlify builds a preview)

Diagnostic experiment for the **desktop version-switcher "Error 500"** (React `insertBefore` crash inside Mintlify's bundle). Fires when the version tree opens on **desktop** (inline sidebar); mobile/tablet drawer is unaffected.

### Hypothesis
Crash is triggered by our **unsupported nesting** `tab → dropdowns → versions → groups`. Mintlify requires one child-type per level, and versions-inside-dropdowns is an open, unsupported feature request ([mintlify/discussions#2168](https://github.com/orgs/mintlify/discussions/2168)). Onset ~2 days ago with **no structural change on our side** ⇒ Mintlify platform regression that stopped tolerating the nesting.

### What this branch changes — Voice & Video Calling only
`SDK` tab's framework dropdowns (JavaScript, React Native, iOS, Android, Flutter), which nested `versions` inside a `dropdown`, are converted to **framework tabs carrying `versions` directly** — Mintlify's supported *"versions applied to a specific tab"* pattern. No page paths changed.

### The A/B (both on this one preview)
- ✅ expected: **Voice & Video** page `calls/javascript/overview` opens the version switcher **without** a 500
- ❌ expected: **Chat & Messaging** control `ui-kit/react/overview` (left nested) **still** 500s

If that split holds, nesting is confirmed as the cause → roll `tab → versions` out site-wide.

_Note: diff vs `main` also includes the prior invisible-char cleanup from `docs/broken-version-tree-fix`; the meaningful change is the V&V flatten. Not for merge._

🤖 Generated with [Claude Code](https://claude.com/claude-code)