### PR TITLE
docs(nav): strip invisible U+200E marks from version labels (preview experiment)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1111,7 +1111,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v5‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -1228,7 +1228,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -1391,7 +1391,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -1413,7 +1413,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -1441,7 +1441,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -1550,7 +1550,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -1714,7 +1714,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -1736,7 +1736,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -1764,7 +1764,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v6‎‎‎",
+                    "version": "v6",
                     "groups": [
                       {
                         "group": " ",
@@ -1883,7 +1883,7 @@
                     ]
                   },
                   {
-                    "version": "v5‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2000,7 +2000,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -2157,7 +2157,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -2182,7 +2182,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -2211,7 +2211,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v6‎‎‎‎",
+                    "version": "v6",
                     "groups": [
                       {
                         "group": " ",
@@ -2327,7 +2327,7 @@
                     ]
                   },
                   {
-                    "version": "v5‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2431,7 +2431,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -2607,7 +2607,7 @@
                 "icon": "/images/icons/angular.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2823,7 +2823,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3013,7 +3013,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3034,7 +3034,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3061,7 +3061,7 @@
                 "icon": "/images/icons/vuejs.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3154,7 +3154,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3176,7 +3176,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3208,7 +3208,7 @@
                 "icon": "/images/icons/js.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3304,7 +3304,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3427,7 +3427,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3530,7 +3530,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3613,7 +3613,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3727,7 +3727,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3829,7 +3829,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3919,7 +3919,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -4037,7 +4037,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -4144,7 +4144,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -4246,7 +4246,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -4340,7 +4340,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -4460,7 +4460,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -4563,7 +4563,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -4655,7 +4655,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -4747,7 +4747,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -5355,7 +5355,7 @@
                 "icon": "/images/icons/js.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5432,7 +5432,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5480,7 +5480,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5548,7 +5548,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5595,7 +5595,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5663,7 +5663,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5710,7 +5710,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5778,7 +5778,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5824,7 +5824,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5892,7 +5892,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",


### PR DESCRIPTION
## What

Removes all 392 invisible **U+200E (Left-to-Right Mark)** characters from the 49 `"version"` labels in `docs.json` navigation. Only `.version` fields change — no paths, dropdown names, or content are touched (verified by audit: every U+200E in the file was on a `"version"` line).

The marks were a historical workaround to keep same-named version labels (v5, v4, …) in different dropdowns from colliding, from before Mintlify officially supported versions nested inside dropdowns.

## Why (experiment — do not merge before preview checks)

This is a controlled experiment for the **version-selector "Error 500 / Error loading page" crash** seen on production and staging. There are two competing diagnoses:

1. **Polluted labels**: the U+200E-suffixed labels break the version switcher's routing.
2. **Platform bug**: a client-side React crash (`NotFoundError: Failed to execute 'insertBefore' on 'Node'`) in Mintlify's hosted bundle when the dropdown opens — reproduced on the **React** dropdown whose labels contain **no** marks, intermittently (clicks shortly after page load), with the URL unchanged.

The local CLI does not run the production renderer, so only the **Mintlify preview deploy** of this branch can settle it.

## Verification on the preview deploy

1. Open `/ui-kit/react/overview` on the preview, and **immediately** real-click the version selector (`v7` chip in the sidebar). Repeat a few times with hard reloads. Does the Error 500 still occur?
2. Open each framework dropdown's version menu (React, React Native, iOS, Android, Flutter, Angular, Vue + SDK tabs) and confirm same-named versions did **not merge across dropdowns** and each version routes to the correct per-framework page.
3. Spot-check destination pages still return 200: `/ui-kit/react/v6/overview`, `/sdk/android/v5/overview`, etc.

If the crash persists with clean labels, diagnosis 2 is confirmed and this becomes evidence for the Mintlify support ticket (deployed chunk `f486afc314643ce1.js`, deployment `dpl_FrDoQHZJuUUsA7qTxqB1HKX9E3Xx`). If versions merge across dropdowns in the preview, close this PR unmerged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)