### PR TITLE
docs: remove empty fonts config causing malformed Google Fonts requests

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -8,14 +8,6 @@
     "light": "#6851D6",
     "dark": "#6851D6"
   },
-  "fonts": {
-    "heading": {
-      "family": ""
-    },
-    "body": {
-      "family": ""
-    }
-  },
   "contextual": {
     "options": [
       "claude",


### PR DESCRIPTION
## What

Deletes the `fonts` block from `docs.json`:

```json
"fonts": {
  "heading": { "family": "" },
  "body": { "family": "" }
}
```

## Why

The empty `family` strings make Mintlify build a Google Fonts URL with no font name — `css2?family=:ital,wght@0,400;…` — on every page load. Google returns an error page, and Chrome DevTools flags it as **CORB-blocked response** + **failed stylesheet** (2 failing requests per page view, visible in the Issues panel on production).

The site already renders with Mintlify's default font stack (the custom-font request has never succeeded), so removing the block changes nothing visually — it just eliminates the guaranteed-failing requests. If a custom font was ever intended, it can be re-added with a real family name.

Unrelated to the version-selector Error 500 investigation (#457) — this is independent cleanup found while debugging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)