### PR TITLE
[A/B v2 — do not merge] V&V versions→tabs, test version-tree 500

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1111,7 +1111,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v5‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -1228,7 +1228,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -1391,7 +1391,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -1413,7 +1413,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -1441,7 +1441,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -1550,7 +1550,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -1714,7 +1714,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -1736,7 +1736,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -1764,7 +1764,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v6‎‎‎",
+                    "version": "v6",
                     "groups": [
                       {
                         "group": " ",
@@ -1883,7 +1883,7 @@
                     ]
                   },
                   {
-                    "version": "v5‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2000,7 +2000,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -2157,7 +2157,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -2182,7 +2182,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -2211,7 +2211,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v6‎‎‎‎",
+                    "version": "v6",
                     "groups": [
                       {
                         "group": " ",
@@ -2327,7 +2327,7 @@
                     ]
                   },
                   {
-                    "version": "v5‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2431,7 +2431,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -2607,7 +2607,7 @@
                 "icon": "/images/icons/angular.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -2823,7 +2823,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3013,7 +3013,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3034,7 +3034,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3061,7 +3061,7 @@
                 "icon": "/images/icons/vuejs.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3154,7 +3154,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3176,7 +3176,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3208,7 +3208,7 @@
                 "icon": "/images/icons/js.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3304,7 +3304,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3427,7 +3427,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3530,7 +3530,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3613,7 +3613,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -3727,7 +3727,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -3829,7 +3829,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -3919,7 +3919,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -4037,7 +4037,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -4144,7 +4144,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -4246,7 +4246,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -4340,7 +4340,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -4460,7 +4460,7 @@
                     ]
                   },
                   {
-                    "version": "v2‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v2",
                     "groups": [
                       {
                         "group": " ",
@@ -4563,7 +4563,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": " ",
@@ -4655,7 +4655,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -4747,7 +4747,7 @@
                     ]
                   },
                   {
-                    "version": "v3‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v3",
                     "groups": [
                       {
                         "group": " ",
@@ -5355,7 +5355,7 @@
                 "icon": "/images/icons/js.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5432,7 +5432,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5480,7 +5480,7 @@
                 "icon": "/images/icons/react.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5548,7 +5548,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5595,7 +5595,7 @@
                 "icon": "/images/icons/swift.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5663,7 +5663,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5710,7 +5710,7 @@
                 "icon": "/images/icons/android.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5778,7 +5778,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",
@@ -5824,7 +5824,7 @@
                 "icon": "/images/icons/flutter.svg",
                 "versions": [
                   {
-                    "version": "v5‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v5",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5892,7 +5892,7 @@
                     ]
                   },
                   {
-                    "version": "v4‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎‎",
+                    "version": "v4",
                     "groups": [
                       {
                         "group": " ",

--- a/docs.json
+++ b/docs.json
@@ -5349,13 +5349,14 @@
           },
           {
             "tab": "SDK",
-            "dropdowns": [
+            "versions": [
               {
-                "dropdown": "JavaScript",
-                "icon": "/images/icons/js.svg",
-                "versions": [
+                "version": "v5",
+                "default": true,
+                "tabs": [
                   {
-                    "version": "v5",
+                    "tab": "JavaScript",
+                    "icon": "/images/icons/js.svg",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5432,55 +5433,8 @@
                     ]
                   },
                   {
-                    "version": "v4",
-                    "groups": [
-                      {
-                        "group": " ",
-                        "pages": [
-                          "calls/v4/javascript/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/javascript/setup"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/javascript/ringing",
-                              "calls/v4/javascript/call-session",
-                              "calls/v4/javascript/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/javascript/recording",
-                              "calls/v4/javascript/call-logs",
-                              "calls/v4/javascript/session-timeout"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/javascript/video-view-customisation",
-                              "calls/v4/javascript/presenter-mode",
-                              "calls/v4/javascript/virtual-background",
-                              "calls/v4/javascript/custom-css"
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "dropdown": "React Native",
-                "icon": "/images/icons/react.svg",
-                "versions": [
-                  {
-                    "version": "v5",
+                    "tab": "React Native",
+                    "icon": "/images/icons/react.svg",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5548,54 +5502,8 @@
                     ]
                   },
                   {
-                    "version": "v4",
-                    "groups": [
-                      {
-                        "group": " ",
-                        "pages": [
-                          "calls/v4/react-native/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/react-native/setup",
-                              "calls/v4/react-native/expo-integration-guide"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/react-native/ringing",
-                              "calls/v4/react-native/call-session",
-                              "calls/v4/react-native/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/react-native/recording",
-                              "calls/v4/react-native/call-logs",
-                              "calls/v4/react-native/session-timeout"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/react-native/video-view-customisation",
-                              "calls/v4/react-native/presenter-mode"
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "dropdown": "iOS",
-                "icon": "/images/icons/swift.svg",
-                "versions": [
-                  {
-                    "version": "v5",
+                    "tab": "iOS",
+                    "icon": "/images/icons/swift.svg",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5663,54 +5571,8 @@
                     ]
                   },
                   {
-                    "version": "v4",
-                    "groups": [
-                      {
-                        "group": " ",
-                        "pages": [
-                          "calls/v4/ios/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/ios/setup"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/ios/ringing",
-                              "calls/v4/ios/call-session",
-                              "calls/v4/ios/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/ios/recording",
-                              "calls/v4/ios/call-logs",
-                              "calls/v4/ios/session-timeout",
-                              "calls/v4/ios/launch-call-screen-on-tap-of-push-notification"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/ios/video-view-customisation",
-                              "calls/v4/ios/presenter-mode"
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "dropdown": "Android",
-                "icon": "/images/icons/android.svg",
-                "versions": [
-                  {
-                    "version": "v5",
+                    "tab": "Android",
+                    "icon": "/images/icons/android.svg",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5778,53 +5640,8 @@
                     ]
                   },
                   {
-                    "version": "v4",
-                    "groups": [
-                      {
-                        "group": " ",
-                        "pages": [
-                          "calls/v4/android/overview",
-                          {
-                            "group": "Getting Started",
-                            "pages": [
-                              "calls/v4/android/setup"
-                            ]
-                          },
-                          {
-                            "group": "Calling Flows",
-                            "pages": [
-                              "calls/v4/android/ringing",
-                              "calls/v4/android/call-session",
-                              "calls/v4/android/standalone-calling"
-                            ]
-                          },
-                          {
-                            "group": "Features",
-                            "pages": [
-                              "calls/v4/android/recording",
-                              "calls/v4/android/call-logs",
-                              "calls/v4/android/session-timeout"
-                            ]
-                          },
-                          {
-                            "group": "Customisation",
-                            "pages": [
-                              "calls/v4/android/video-view-customisation",
-                              "calls/v4/android/presenter-mode"
-                            ]
-                          }
-                        ]
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "dropdown": "Flutter",
-                "icon": "/images/icons/flutter.svg",
-                "versions": [
-                  {
-                    "version": "v5",
+                    "tab": "Flutter",
+                    "icon": "/images/icons/flutter.svg",
                     "groups": [
                       {
                         "group": "Overview",
@@ -5890,9 +5707,183 @@
                         ]
                       }
                     ]
+                  }
+                ]
+              },
+              {
+                "version": "v4",
+                "tabs": [
+                  {
+                    "tab": "JavaScript",
+                    "icon": "/images/icons/js.svg",
+                    "groups": [
+                      {
+                        "group": " ",
+                        "pages": [
+                          "calls/v4/javascript/overview",
+                          {
+                            "group": "Getting Started",
+                            "pages": [
+                              "calls/v4/javascript/setup"
+                            ]
+                          },
+                          {
+                            "group": "Calling Flows",
+                            "pages": [
+                              "calls/v4/javascript/ringing",
+                              "calls/v4/javascript/call-session",
+                              "calls/v4/javascript/standalone-calling"
+                            ]
+                          },
+                          {
+                            "group": "Features",
+                            "pages": [
+                              "calls/v4/javascript/recording",
+                              "calls/v4/javascript/call-logs",
+                              "calls/v4/javascript/session-timeout"
+                            ]
+                          },
+                          {
+                            "group": "Customisation",
+                            "pages": [
+                              "calls/v4/javascript/video-view-customisation",
+                              "calls/v4/javascript/presenter-mode",
+                              "calls/v4/javascript/virtual-background",
+                              "calls/v4/javascript/custom-css"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
                   },
                   {
-                    "version": "v4",
+                    "tab": "React Native",
+                    "icon": "/images/icons/react.svg",
+                    "groups": [
+                      {
+                        "group": " ",
+                        "pages": [
+                          "calls/v4/react-native/overview",
+                          {
+                            "group": "Getting Started",
+                            "pages": [
+                              "calls/v4/react-native/setup",
+                              "calls/v4/react-native/expo-integration-guide"
+                            ]
+                          },
+                          {
+                            "group": "Calling Flows",
+                            "pages": [
+                              "calls/v4/react-native/ringing",
+                              "calls/v4/react-native/call-session",
+                              "calls/v4/react-native/standalone-calling"
+                            ]
+                          },
+                          {
+                            "group": "Features",
+                            "pages": [
+                              "calls/v4/react-native/recording",
+                              "calls/v4/react-native/call-logs",
+                              "calls/v4/react-native/session-timeout"
+                            ]
+                          },
+                          {
+                            "group": "Customisation",
+                            "pages": [
+                              "calls/v4/react-native/video-view-customisation",
+                              "calls/v4/react-native/presenter-mode"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "tab": "iOS",
+                    "icon": "/images/icons/swift.svg",
+                    "groups": [
+                      {
+                        "group": " ",
+                        "pages": [
+                          "calls/v4/ios/overview",
+                          {
+                            "group": "Getting Started",
+                            "pages": [
+                              "calls/v4/ios/setup"
+                            ]
+                          },
+                          {
+                            "group": "Calling Flows",
+                            "pages": [
+                              "calls/v4/ios/ringing",
+                              "calls/v4/ios/call-session",
+                              "calls/v4/ios/standalone-calling"
+                            ]
+                          },
+                          {
+                            "group": "Features",
+                            "pages": [
+                              "calls/v4/ios/recording",
+                              "calls/v4/ios/call-logs",
+                              "calls/v4/ios/session-timeout",
+                              "calls/v4/ios/launch-call-screen-on-tap-of-push-notification"
+                            ]
+                          },
+                          {
+                            "group": "Customisation",
+                            "pages": [
+                              "calls/v4/ios/video-view-customisation",
+                              "calls/v4/ios/presenter-mode"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "tab": "Android",
+                    "icon": "/images/icons/android.svg",
+                    "groups": [
+                      {
+                        "group": " ",
+                        "pages": [
+                          "calls/v4/android/overview",
+                          {
+                            "group": "Getting Started",
+                            "pages": [
+                              "calls/v4/android/setup"
+                            ]
+                          },
+                          {
+                            "group": "Calling Flows",
+                            "pages": [
+                              "calls/v4/android/ringing",
+                              "calls/v4/android/call-session",
+                              "calls/v4/android/standalone-calling"
+                            ]
+                          },
+                          {
+                            "group": "Features",
+                            "pages": [
+                              "calls/v4/android/recording",
+                              "calls/v4/android/call-logs",
+                              "calls/v4/android/session-timeout"
+                            ]
+                          },
+                          {
+                            "group": "Customisation",
+                            "pages": [
+                              "calls/v4/android/video-view-customisation",
+                              "calls/v4/android/presenter-mode"
+                            ]
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  {
+                    "tab": "Flutter",
+                    "icon": "/images/icons/flutter.svg",
                     "groups": [
                       {
                         "group": " ",


### PR DESCRIPTION
## A/B test v2 — NOT for merge

Second attempt to test whether restructuring away from the crashing version-switcher shape stops the desktop **Error 500** (`insertBefore` crash in Mintlify's bundle `f486afc314643ce1.js`).

v1 (`tab → versions`) broke V&V routing. This v2 uses the documented **"versions containing tabs"** pattern:

`SDK tab → versions[v5 (default:true), v4] → tabs[JavaScript, React Native, iOS, Android, Flutter] → groups`

- `v5` is `default` so canonical URLs stay unprefixed (e.g. `/calls/javascript/overview`).
- **Verified with `mintlify dev`:** all V&V pages route (200 + real content) and the page renders a v5 version selector + the five framework tabs. Page paths unchanged.

### Test on this preview
1. Confirm `/calls/javascript/overview` renders V&V content (routing OK).
2. Open the version switcher on that page (desktop viewport) → does it 500?
3. Control: `/ui-kit/react/overview` (Chat, still nested) should still 500.

Note: the config that crashes is **schema-valid** per Mintlify's own docs.json schema, so this is a Mintlify runtime bug regardless; this A/B only tests whether a different (also-valid) shape happens to avoid it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)