### PR TITLE
docs: customer mitigation — banner + direct-link versions page while version selector is broken

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,6 +3,11 @@
   "theme": "aspen",
   "name": "CometChat Docs",
   "description": "Technical documentation & Implementation guides to add In-app Messaging & Voice & Video Calling to your apps and websites in minutes.",
+  "banner": {
+    "content": "The version selector is temporarily unavailable. [Open any version directly →](/versions)",
+    "type": "warning",
+    "dismissible": true
+  },
   "colors": {
     "primary": "#6851D6",
     "light": "#6851D6",

--- a/versions.mdx
+++ b/versions.mdx
@@ -1,0 +1,46 @@
+---
+title: "All documentation versions"
+description: "Direct links to every version of the CometChat UI Kits and SDKs while the version selector is being fixed."
+---
+
+The in-page version selector is temporarily unavailable. Use the direct links below to open any version of the documentation.
+
+## Chat & Messaging — UI Kits
+
+**React:** [v7](/ui-kit/react/overview) · [v6](/ui-kit/react/v6/overview) · [v5](/ui-kit/react/v5/overview) · [v4](/ui-kit/react/v4/overview) · [v3](/ui-kit/react/v3/overview) · [v2](/ui-kit/react/v2/overview)
+
+**React Native:** [v5](/ui-kit/react-native/overview) · [v4](/ui-kit/react-native/v4/overview) · [v3](/ui-kit/react-native/v3/overview) · [v2](/ui-kit/react-native/v2/overview)
+
+**iOS:** [v5](/ui-kit/ios/overview) · [v4](/ui-kit/ios/v4/overview) · [v3](/ui-kit/ios/v3/overview) · [v2](/ui-kit/ios/v2/overview)
+
+**Android:** [v6](/ui-kit/android/overview) · [v5](/ui-kit/android/v5/overview) · [v4](/ui-kit/android/v4/overview) · [v3](/ui-kit/android/v3/overview) · [v2](/ui-kit/android/v2/overview)
+
+**Flutter:** [v6](/ui-kit/flutter/overview) · [v5](/ui-kit/flutter/v5/overview) · [v4](/ui-kit/flutter/v4/overview)
+
+**Angular:** [v5](/ui-kit/angular/overview) · [v4](/ui-kit/angular/v4/overview) · [v3](/ui-kit/angular/3.0/overview) · [v2](/ui-kit/angular/2.0/overview)
+
+**Vue:** [v4](/ui-kit/vue/overview) · [v3](/ui-kit/vue/3.0/overview) · [v2](/ui-kit/vue/2.0/overview)
+
+## Chat & Messaging — SDKs
+
+**JavaScript:** [v4](/sdk/javascript/overview) · [v3](/sdk/javascript/3.0/overview) · [v2](/sdk/javascript/2.0/overview)
+
+**React Native:** [v4](/sdk/react-native/overview) · [v3](/sdk/react-native/3.0/overview) · [v2](/sdk/react-native/2.0/overview)
+
+**iOS:** [v4](/sdk/ios/overview) · [v3](/sdk/ios/3.0/overview) · [v2](/sdk/ios/2.0/overview)
+
+**Android:** [v5](/sdk/android/v5/overview) · [v4](/sdk/android/overview) · [v3](/sdk/android/3.0/overview) · [v2](/sdk/android/2.0/overview)
+
+**Flutter:** [v5](/sdk/flutter/overview) · [v4](/sdk/flutter/v4/overview) · [v3](/sdk/flutter/3.0/overview)
+
+## Voice & Video Calling — SDK
+
+**JavaScript:** [v5](/calls/javascript/overview) · [v4](/calls/v4/javascript/overview)
+
+**React Native:** [v5](/calls/react-native/overview) · [v4](/calls/v4/react-native/overview)
+
+**iOS:** [v5](/calls/ios/overview) · [v4](/calls/v4/ios/overview)
+
+**Android:** [v5](/calls/android/overview) · [v4](/calls/v4/android/overview)
+
+**Flutter:** [v5](/calls/flutter/overview) · [v4](/calls/v4/flutter/overview)


### PR DESCRIPTION
## Why (customer-impacting incident)

The desktop version-selector dropdown on production crashes to Mintlify's "Error 500 / Error loading page" (client-side `insertBefore` crash in their bundle — platform bug, reported to Mintlify; see #457 for the full investigation). Customers currently cannot switch doc versions in the UI. **Every versioned page URL still serves fine** — only the switcher widget is broken.

## What

1. **Site-wide dismissible warning banner**: *"The version selector is temporarily unavailable. [Open any version directly →](/versions)"*
2. **`/versions` page** (hidden — not in navigation, reachable by URL): direct links to every version of all 17 versioned dropdowns (UI Kits, Chat SDKs, Calls SDKs), generated from docs.json navigation.

## Verification on preview

- Banner renders on all pages and dismisses correctly
- `/versions` loads and links resolve to the right per-framework version trees

## Rollback

Revert this single commit once Mintlify fixes the selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)