### PR TITLE
docs(ui-kit/react): reconcile contradictory plugin precedence (ENG-37996)

### DIFF
--- a/ui-kit/react/plugins/custom-plugin.mdx
+++ b/ui-kit/react/plugins/custom-plugin.mdx
@@ -121,7 +121,7 @@ function App() {
 }
 ```
 
-Your plugin is appended after the default plugins. Since resolution is first-match, default plugins handle their types first, and your plugin handles `"location"` messages.
+Your plugin is prepended before the default plugins. Since resolution is first-match, your custom plugins take precedence for the types they declare — here the plugin handles `"location"` messages, a type no built-in plugin claims. To override a built-in type instead, declare the same `messageTypes`/`messageCategories` as the default plugin.
 
 ## Step 3: Send a Location Message
 

--- a/ui-kit/react/plugins/overview.mdx
+++ b/ui-kit/react/plugins/overview.mdx
@@ -60,7 +60,7 @@ When the UI Kit needs to render a message, it asks the **Plugin Registry** to fi
 
 1. If the message is deleted (`getDeletedAt() !== null`), the Delete plugin handles it
 2. Otherwise, the registry finds the first plugin whose `messageTypes` includes the message's type AND whose `messageCategories` includes the message's category
-3. First match wins — plugin order matters
+3. First match wins — plugin order matters. Custom plugins passed via the `plugins` prop are placed **before** the defaults, so a custom plugin can override a built-in one for the same type
 
 ```
 Message { type: "image", category: "message" }
@@ -69,11 +69,15 @@ Message { type: "image", category: "message" }
   → ImagePlugin.renderBubble() is called
 ```
 
+<Note>
+Precedence is determined by **plugin order** (your custom plugins first, defaults after) and matched by `messageTypes` + `messageCategories` — **not** by `id`. The `id` field is a required unique identifier for the plugin; it is not the override mechanism.
+</Note>
+
 ---
 
 ## Adding Plugins
 
-All default plugins are always included. To add your own custom plugins, pass them via the `plugins` prop on `CometChatProvider`. They are appended after the defaults, so default plugins keep priority for their message types:
+All default plugins are always included. To add your own custom plugins, pass them via the `plugins` prop on `CometChatProvider`. They are **prepended before the defaults**, so a custom plugin takes priority for its message types (first match wins) — letting you override a built-in plugin by declaring the same `messageTypes`/`messageCategories`:
 
 ```tsx
 import { CometChatProvider } from "@cometchat/chat-uikit-react";

--- a/ui-kit/react/plugins/text-formatters.mdx
+++ b/ui-kit/react/plugins/text-formatters.mdx
@@ -139,7 +139,7 @@ import { CustomTextPlugin } from "./plugins/CustomTextPlugin";
 </CometChatProvider>
 ```
 
-Since user plugins are prepended before the defaults in the registry, your custom text plugin takes precedence over the built-in one (first match wins)
+Since user plugins are prepended before the defaults in the registry, your custom text plugin takes precedence over the built-in one (first match wins).
 
 ## Formatter Details
 


### PR DESCRIPTION
## What & why

Fixes **ENG-37996** — the React UI Kit **v7** plugin docs contradicted each other on whether a custom plugin overrides a built-in one:

| File | Claimed |
| --- | --- |
| `ui-kit/react/plugins/overview.mdx` | custom plugins "appended after the defaults", "default plugins keep priority" ❌ |
| `ui-kit/react/plugins/custom-plugin.mdx` | "appended after the default plugins… default plugins handle their types first" ❌ |
| `ui-kit/react/plugins/text-formatters.mdx` | "prepended before the defaults… takes precedence (first match wins)" ✅ |

Two pages said defaults win; one said the custom plugin wins. Since resolution is explicitly "first match wins", they can't all be true.

## Ground truth (verified against the shipped package)

Confirmed against **`@cometchat/chat-uikit-react` v7.1.0** (npm tarball), not inference:

- `CometChatProvider` builds the registry as `[...plugins, ...defaultPlugins]` — **user-supplied `plugins` come first**, defaults after (`dist/index.js:6099`).
- `CometChatPluginRegistry` resolves a message with `.find(...)` — **first match wins**, scanning from index 0 (`dist/index.js:350`).

So custom plugins **are prepended and do take precedence**. `text-formatters.mdx` was the correct page; `overview.mdx` and `custom-plugin.mdx` were wrong.

## Changes

- **`overview.mdx`** — "Adding Plugins" now says custom plugins are prepended and take priority (enabling override of a built-in by declaring the same `messageTypes`/`messageCategories`); added a resolution note that precedence is by **plugin order + `messageTypes`/`messageCategories`, not `id`**.
- **`custom-plugin.mdx`** — Step 2 explanation corrected to "prepended before the defaults", with a note on how to override a built-in type.
- **`text-formatters.mdx`** — already correct; added a missing trailing period only.

## Scope / notes

- Docs-only; no other pages made the stale claim (grepped the repo).
- The one open item from the ticket handled here is the contradiction + `id` clarification. The remaining ticket recommendations (index the v7 source into the KB, boost v7 doc ranking, update the validation critic's ground-truth) are **AI-knowledge-base** tasks, not docs edits, and are out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)