### PR TITLE
docs: calls sdk improvements

### DIFF
--- a/calls/android/recording.mdx
+++ b/calls/android/recording.mdx
@@ -72,6 +72,13 @@ SessionSettings sessionSettings = new CometChatCalls.SessionSettingsBuilder()
 </Tab>
 </Tabs>
 
+<Note>
+**A recording runs until it is stopped.** Whether it was started manually or automatically through `enableAutoStartRecording`, it keeps running until someone stops it. If nobody does, it stops on its own when either:
+
+- Everyone leaves the session — the recording ends about a minute later.
+- Everyone in the session stays muted for 10 minutes.
+</Note>
+
 ## Hide Recording Button
 
 Hide the recording button from the default call UI:

--- a/calls/flutter/recording.mdx
+++ b/calls/flutter/recording.mdx
@@ -39,6 +39,13 @@ SessionSettings sessionSettings = CometChatCalls.SessionSettingsBuilder()
     .build();
 ```
 
+<Note>
+**A recording runs until it is stopped.** Whether it was started manually or automatically through `enableAutoStartRecording`, it keeps running until someone stops it. If nobody does, it stops on its own when either:
+
+- Everyone leaves the session — the recording ends about a minute later.
+- Everyone in the session stays muted for 10 minutes.
+</Note>
+
 ## Hide Recording Button
 
 Hide the recording button from the default call UI:

--- a/calls/ios/recording.mdx
+++ b/calls/ios/recording.mdx
@@ -68,6 +68,13 @@ SessionSettings *sessionSettings = [[[CometChatCalls sessionSettingsBuilder]
 </Tab>
 </Tabs>
 
+<Note>
+**A recording runs until it is stopped.** Whether it was started manually or automatically through `enableAutoStartRecording`, it keeps running until someone stops it. If nobody does, it stops on its own when either:
+
+- Everyone leaves the session — the recording ends about a minute later.
+- Everyone in the session stays muted for 10 minutes.
+</Note>
+
 ## Hide Recording Button
 
 Hide the recording button from the default call UI:

--- a/calls/javascript/actions.mdx
+++ b/calls/javascript/actions.mdx
@@ -184,6 +184,10 @@ Ends your participation and disconnects gracefully. The call continues for other
 CometChatCalls.leaveSession();
 ```
 
+<Note>
+`leaveSession()` takes no session ID. `CometChatCalls` is a singleton that tracks one active session at a time, so this leaves whichever session is currently in progress. The same applies to every action on this page. See [Single Active Session](/calls/javascript/overview#single-active-session).
+</Note>
+
 ## UI Controls
 
 ### Show Settings Dialog

--- a/calls/javascript/join-session.mdx
+++ b/calls/javascript/join-session.mdx
@@ -135,6 +135,21 @@ try {
 All participants joining the same call must use the same session ID.
 </Note>
 
+## One Session at a Time
+
+`CometChatCalls` is a singleton that holds a single active session. Joining a second session while one is in progress is not supported - leave the current session first, wait for `onSessionLeft`, then join the next one.
+
+```javascript
+CometChatCalls.addEventListener("onSessionLeft", async () => {
+  const { token } = await CometChatCalls.generateToken(nextSessionId);
+  await CometChatCalls.joinSession(token, callSettings, container);
+});
+
+CometChatCalls.leaveSession();
+```
+
+This is also why `leaveSession()` and the other [actions](/calls/javascript/actions) take no session ID - they always apply to the session that is currently active. See [Single Active Session](/calls/javascript/overview#single-active-session) for the full behavior.
+
 ## Error Handling
 
 Common errors when joining a session:

--- a/calls/javascript/migration-guide-v5.mdx
+++ b/calls/javascript/migration-guide-v5.mdx
@@ -209,6 +209,20 @@ CometChatCalls.generateToken(sessionId).then((token) => {
 
 Static methods remain on `CometChatCalls` but some have been renamed.
 
+<Note>
+**Boolean toggles are now paired methods.** In v4, `muteAudio()` took a boolean: `muteAudio(true)` muted the mic and `muteAudio(false)` unmuted it. In v5 these are two separate, argument-free methods — replace `muteAudio(true)` with `muteAudio()` and `muteAudio(false)` with `unmuteAudio()`. The same split applies to `pauseVideo(true)` / `pauseVideo(false)`, which become `pauseVideo()` and `resumeVideo()`.
+</Note>
+
+```javascript
+// v4
+CometChatCalls.muteAudio(true);   // mute
+CometChatCalls.muteAudio(false);  // unmute
+
+// v5
+CometChatCalls.muteAudio();       // mute
+CometChatCalls.unmuteAudio();     // unmute
+```
+
 | v4 Method | v5 Method |
 |---|---|
 | `CometChatCalls.endSession()` | `CometChatCalls.leaveSession()` |

--- a/calls/javascript/migration-guide-v5.mdx
+++ b/calls/javascript/migration-guide-v5.mdx
@@ -303,6 +303,24 @@ CometChatCalls.addEventListener("onCallLayoutChanged", (layoutType) => { });
 `addEventListener()` returns an unsubscribe function. Call it to remove the listener. You can also pass an `AbortSignal` for cleanup.
 </Note>
 
+### New Events Require `addEventListener()`
+
+The events introduced in v5 are only delivered through `addEventListener()`. None of the v4 registration paths — `setCallListener()` / `setCallEventListener()` on `CallSettingsBuilder` and `CometChatCalls.addCallEventListener(name, listener)` — will ever fire them, because `OngoingCallListener` only carries the legacy v4 event set. Events such as `onSessionJoined`, `onConnectionLost`, `onLeaveSessionButtonClicked`, and `onCallLayoutChanged` are unreachable from a v4 listener no matter how it is registered.
+
+You don't have to migrate everything at once. `addEventListener()` works alongside an existing v4 listener without breaking it — keep your current `OngoingCallListener` for the legacy events and add `addEventListener()` subscriptions for the new ones.
+
+```javascript
+// Existing v4 listener keeps working
+CometChatCalls.addCallEventListener("MY_LISTENER", new CometChatCalls.OngoingCallListener({
+  onCallEnded: () => { },
+  onUserJoined: (user) => { },
+}));
+
+// Add v5-only events alongside it
+CometChatCalls.addEventListener("onConnectionLost", () => { });
+CometChatCalls.addEventListener("onCallLayoutChanged", (layoutType) => { });
+```
+
 ### Event Mapping
 
 | v4 Event | v5 Event |

--- a/calls/javascript/overview.mdx
+++ b/calls/javascript/overview.mdx
@@ -142,6 +142,40 @@ The SDK is organized around these core components:
 | `CallSettings` | Configuration object for individual call sessions |
 | `addEventListener` | Method to register event listeners for session, participant, media, and UI events |
 
+## Single Active Session
+
+`CometChatCalls` is a singleton, and it tracks one active call session at a time. Every session method acts on that current session, which is why methods like `leaveSession()` take no session ID:
+
+```javascript
+// Joins and becomes the active session
+await CometChatCalls.joinSession(callToken, callSettings, container);
+
+// Acts on whatever session is currently active - no session ID needed
+CometChatCalls.leaveSession();
+```
+
+| Behavior | Detail |
+|----------|--------|
+| One session at a time | The SDK does not support being connected to two sessions simultaneously. Leave the current session before joining another. |
+| Session methods take no session ID | `leaveSession()` and the other [actions](/calls/javascript/actions) apply to the active session only. |
+| Actions apply to the active session | `muteAudio()`, `pauseVideo()`, `startScreenShare()`, and similar methods target the session currently in progress. |
+| Events are not session-scoped | Listeners registered with `addEventListener` fire for the active session. |
+
+To move a user from one call to another, leave the current session, wait for the `onSessionLeft` event, then generate a token for the new session and join:
+
+```javascript
+CometChatCalls.addEventListener("onSessionLeft", async () => {
+  const { token } = await CometChatCalls.generateToken(nextSessionId);
+  await CometChatCalls.joinSession(token, callSettings, container);
+});
+
+CometChatCalls.leaveSession();
+```
+
+<Note>
+The limit applies per SDK instance. Separate browser tabs or windows each load their own instance, so they can hold separate sessions independently.
+</Note>
+
 ## Sample App
 
 <CardGroup cols={3}>

--- a/calls/javascript/recording.mdx
+++ b/calls/javascript/recording.mdx
@@ -42,6 +42,13 @@ Stop the current recording:
 CometChatCalls.stopRecording();
 ```
 
+<Note>
+**A recording runs until it is stopped.** Whether it was started manually or automatically through `autoStartRecording`, it keeps running until someone stops it. If nobody does, it stops on its own when either:
+
+- Everyone leaves the session — the recording ends about a minute later.
+- Everyone in the session stays muted for 10 minutes.
+</Note>
+
 ## Recording Events
 
 ### Recording Started

--- a/calls/react-native/actions.mdx
+++ b/calls/react-native/actions.mdx
@@ -65,6 +65,10 @@ CometChatCalls.leaveSession();
 The `leaveSession()` method ends the call for the local user. Other participants will remain in the call unless they also leave.
 </Note>
 
+<Note>
+`leaveSession()` takes no session ID. `CometChatCalls` is a singleton that tracks one active session at a time, so this leaves whichever session is currently in progress. The same applies to every action on this page. See [Single Active Session](/calls/react-native/overview#single-active-session).
+</Note>
+
 ## Raise Hand
 
 ### Raise Hand

--- a/calls/react-native/join-session.mdx
+++ b/calls/react-native/join-session.mdx
@@ -282,6 +282,21 @@ const styles = StyleSheet.create({
 export default CallScreen;
 ```
 
+## One Session at a Time
+
+`CometChatCalls` is a singleton that holds a single active session. Render one `CometChatCalls.Component` at a time - joining a second session while one is in progress is not supported. Leave the current session first, wait for `onSessionLeft`, then join the next one.
+
+```tsx
+CometChatCalls.addEventListener('onSessionLeft', async () => {
+  const { token } = await CometChatCalls.generateToken(nextSessionId);
+  setCallToken(token); // Re-renders the component with the new session
+}, { signal });
+
+CometChatCalls.leaveSession();
+```
+
+This is also why `leaveSession()` and the other [actions](/calls/react-native/actions) take no session ID - they always apply to the session that is currently active. See [Single Active Session](/calls/react-native/overview#single-active-session) for the full behavior.
+
 ## Error Handling
 
 Common errors when joining a session:

--- a/calls/react-native/migration-guide-v5.mdx
+++ b/calls/react-native/migration-guide-v5.mdx
@@ -304,6 +304,24 @@ CometChatCalls.addEventListener("onPictureInPictureLayoutDisabled", () => { });
 `addEventListener()` returns an unsubscribe function. Call it to remove the listener.
 </Note>
 
+### New Events Require `addEventListener()`
+
+The events introduced in v5 are only delivered through `addEventListener()`. Neither of the v4 registration paths — `setCallEventListener()` on `CallSettingsBuilder` and `CometChatCalls.addCallEventListener(name, listener)` — will ever fire them, because `OngoingCallListener` only carries the legacy v4 event set. Events such as `onSessionJoined`, `onConnectionLost`, `onLeaveSessionButtonClicked`, and `onCallLayoutChanged` are unreachable from a v4 listener no matter how it is registered.
+
+You don't have to migrate everything at once. `addEventListener()` works alongside an existing v4 listener without breaking it — keep your current `OngoingCallListener` for the legacy events and add `addEventListener()` subscriptions for the new ones.
+
+```javascript
+// Existing v4 listener keeps working
+CometChatCalls.addCallEventListener("MY_LISTENER", new CometChatCalls.OngoingCallListener({
+  onCallEnded: () => { },
+  onUserJoined: (user) => { },
+}));
+
+// Add v5-only events alongside it
+CometChatCalls.addEventListener("onConnectionLost", () => { });
+CometChatCalls.addEventListener("onCallLayoutChanged", (layoutType) => { });
+```
+
 ### Event Mapping
 
 | v4 Event | v5 Event |

--- a/calls/react-native/migration-guide-v5.mdx
+++ b/calls/react-native/migration-guide-v5.mdx
@@ -212,6 +212,20 @@ const { token } = await CometChatCalls.generateToken(sessionId);
 
 Static methods remain on `CometChatCalls` but some have been renamed.
 
+<Note>
+**Boolean toggles are now paired methods.** In v4, `muteAudio()` took a boolean: `muteAudio(true)` muted the mic and `muteAudio(false)` unmuted it. In v5 these are two separate, argument-free methods — replace `muteAudio(true)` with `muteAudio()` and `muteAudio(false)` with `unmuteAudio()`. The same split applies to `pauseVideo(true)` / `pauseVideo(false)`, which become `pauseVideo()` and `resumeVideo()`.
+</Note>
+
+```javascript
+// v4
+CometChatCalls.muteAudio(true);   // mute
+CometChatCalls.muteAudio(false);  // unmute
+
+// v5
+CometChatCalls.muteAudio();       // mute
+CometChatCalls.unmuteAudio();     // unmute
+```
+
 | v4 Method | v5 Method |
 |---|---|
 | `CometChatCalls.endSession()` | `CometChatCalls.leaveSession()` |

--- a/calls/react-native/overview.mdx
+++ b/calls/react-native/overview.mdx
@@ -14,7 +14,7 @@ Before integrating the Calls SDK, ensure you have:
 1. **CometChat Account**: [Sign up](https://app.cometchat.com/signup) and create an app to get your App ID, Region, and API Key
 2. **CometChat Users**: Users must exist in CometChat to use calling features. For testing, create users via the [Dashboard](https://app.cometchat.com) or [REST API](/rest-api/users/create). Authentication is handled by the Calls SDK - see [Authentication](/calls/react-native/authentication)
 3. **React Native Requirements**:
-   - React Native 0.71 or later
+   - React Native 0.71 or later (works with both the old architecture and the [New Architecture](/calls/react-native/setup#react-native-new-architecture), including bridgeless mode)
    - Node.js 18 or later
    - iOS: Minimum iOS 13.0, Xcode 14.0+
    - Android: Minimum SDK API Level 24 (Android 7.0)

--- a/calls/react-native/overview.mdx
+++ b/calls/react-native/overview.mdx
@@ -95,6 +95,34 @@ The SDK is organized around these core components:
 | `CometChatCalls.Component` | React component that renders the call UI |
 | `CometChatCalls.addEventListener` | Subscribe to call events; returns an unsubscribe function |
 
+## Single Active Session
+
+`CometChatCalls` is a singleton, and it tracks one active call session at a time. Every session method acts on that current session, which is why methods like `leaveSession()` take no session ID:
+
+```tsx
+// Acts on whatever session is currently active - no session ID needed
+CometChatCalls.leaveSession();
+```
+
+| Behavior | Detail |
+|----------|--------|
+| One session at a time | The SDK does not support being connected to two sessions simultaneously. Leave the current session before joining another. |
+| One `Component` at a time | Render a single `CometChatCalls.Component` for the active call. Mounting two at once is not supported. |
+| Session methods take no session ID | `leaveSession()` and the other [actions](/calls/react-native/actions) apply to the active session only. |
+| Actions apply to the active session | `muteAudio()`, `pauseVideo()`, `switchCamera()`, and similar methods target the session currently in progress. |
+| Events are not session-scoped | Listeners registered with `addEventListener` fire for the active session. |
+
+To move a user from one call to another, leave the current session, wait for the `onSessionLeft` event, then generate a token for the new session and render the component with the new token:
+
+```tsx
+CometChatCalls.addEventListener('onSessionLeft', async () => {
+  const { token } = await CometChatCalls.generateToken(nextSessionId);
+  setCallToken(token); // Re-renders CometChatCalls.Component with the new session
+}, { signal });
+
+CometChatCalls.leaveSession();
+```
+
 ## Related Documentation
 
 - [Setup](/calls/react-native/setup) - Install and configure the SDK

--- a/calls/react-native/recording.mdx
+++ b/calls/react-native/recording.mdx
@@ -46,6 +46,13 @@ Stop an active recording:
 CometChatCalls.stopRecording();
 ```
 
+<Note>
+**A recording runs until it is stopped.** Whether it was started manually or automatically through `autoStartRecording`, it keeps running until someone stops it. If nobody does, it stops on its own when either:
+
+- Everyone leaves the session — the recording ends about a minute later.
+- Everyone in the session stays muted for 10 minutes.
+</Note>
+
 ## Recording Events
 
 Listen for recording state changes:

--- a/calls/react-native/setup.mdx
+++ b/calls/react-native/setup.mdx
@@ -59,6 +59,14 @@ npm install @react-native-async-storage/async-storage@^2.1.2 react-native-backgr
 yarn add @react-native-async-storage/async-storage@^2.1.2 react-native-background-timer@^2.4.1 react-native-performance@^5.1.2 react-native-svg@^15.12.0 react-native-url-polyfill@2.0.0 react-native-webrtc@124.0.7
 ```
 
+## React Native New Architecture
+
+The Calls SDK works with both the old architecture and the New Architecture, including bridgeless mode. No extra setup is needed — leave `newArchEnabled` set to whatever your app requires and follow the same integration steps either way.
+
+<Note>
+The SDK ships as a legacy native module rather than a TurboModule/Fabric component. On the New Architecture it runs through React Native's built-in interop layer, so the API and behavior are identical on both architectures.
+</Note>
+
 ## iOS Configuration
 
 ### Install CocoaPods Dependencies

--- a/calls/v4/android/call-logs.mdx
+++ b/calls/v4/android/call-logs.mdx
@@ -2,8 +2,16 @@
 title: "Call Logs"
 sidebarTitle: "Call Logs"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Logs for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Logs for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/android/call-session.mdx
+++ b/calls/v4/android/call-session.mdx
@@ -2,8 +2,16 @@
 title: "Call Session"
 sidebarTitle: "Call Session"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Session for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Session for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/android/overview.mdx
+++ b/calls/v4/android/overview.mdx
@@ -5,9 +5,13 @@ sdk_version: "4.x"
 description: "CometChat Calling SDK v4 - Legacy Release - Overview for Android. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
-<Note>
-🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/android/overview)
-</Note>
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/android/overview.mdx
+++ b/calls/v4/android/overview.mdx
@@ -2,11 +2,11 @@
 title: "Calling SDK"
 sidebarTitle: "Overview"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Overview for Android. This is the stable v4 documentation. Most users should use this version."
+description: "CometChat Calling SDK v4 - Legacy Release - Overview for Android. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
 <Note>
-🚀 **v5 Beta Available** — The Calling SDK v5 is now available in beta with significant improvements. [Check out the v5 docs →](/calls/android/overview)
+🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/android/overview)
 </Note>
 
 ## Overview

--- a/calls/v4/android/presenter-mode.mdx
+++ b/calls/v4/android/presenter-mode.mdx
@@ -2,8 +2,16 @@
 title: "Presenter Mode"
 sidebarTitle: "Presenter Mode"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Presenter Mode for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Presenter Mode for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/android/recording.mdx
+++ b/calls/v4/android/recording.mdx
@@ -2,8 +2,16 @@
 title: "Recording"
 sidebarTitle: "Recording"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Recording for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Recording for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 This section will guide you to implement call recording feature for the voice and video calls.
 

--- a/calls/v4/android/ringing.mdx
+++ b/calls/v4/android/ringing.mdx
@@ -2,8 +2,16 @@
 title: "Ringing"
 sidebarTitle: "Ringing"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Ringing for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Ringing for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/android/session-timeout.mdx
+++ b/calls/v4/android/session-timeout.mdx
@@ -2,8 +2,16 @@
 title: "Session Timeout Flow"
 sidebarTitle: "Session Timeout"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Session Timeout for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Session Timeout for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 Available since v4.1.0
 

--- a/calls/v4/android/setup.mdx
+++ b/calls/v4/android/setup.mdx
@@ -2,8 +2,16 @@
 title: "Setup"
 sidebarTitle: "Setup"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Setup for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Setup for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 ## Get your Application Keys
 

--- a/calls/v4/android/standalone-calling.mdx
+++ b/calls/v4/android/standalone-calling.mdx
@@ -2,8 +2,16 @@
 title: "Standalone Calling"
 sidebarTitle: "Standalone Calling"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Standalone Calling for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Standalone Calling for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/android/video-view-customisation.mdx
+++ b/calls/v4/android/video-view-customisation.mdx
@@ -2,8 +2,16 @@
 title: "Video View Customisation"
 sidebarTitle: "Video View Customisation"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Video View Customisation for Android"
+description: "CometChat Calling SDK v4 - Legacy Release - Video View Customisation for Android"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Android).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/android/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/android/migration-guide-v5).
+</Warning>
 
 This section will guide you to customise the main video container.
 

--- a/calls/v4/flutter/call-logs.mdx
+++ b/calls/v4/flutter/call-logs.mdx
@@ -2,8 +2,16 @@
 title: "Call Logs"
 sidebarTitle: "Call Logs"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Logs for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Logs for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/flutter/call-session.mdx
+++ b/calls/v4/flutter/call-session.mdx
@@ -2,8 +2,16 @@
 title: "Call Session"
 sidebarTitle: "Call Session"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Session for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Session for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/flutter/overview.mdx
+++ b/calls/v4/flutter/overview.mdx
@@ -2,11 +2,11 @@
 title: "Calling SDK"
 sidebarTitle: "Overview"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Overview for Flutter. This is the stable v4 documentation. Most users should use this version."
+description: "CometChat Calling SDK v4 - Legacy Release - Overview for Flutter. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
 <Note>
-🚀 **v5 Beta Available** — The Calling SDK v5 is now available in beta with significant improvements. [Check out the v5 docs →](/calls/flutter/overview)
+🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/flutter/overview)
 </Note>
 
 ## Overview

--- a/calls/v4/flutter/overview.mdx
+++ b/calls/v4/flutter/overview.mdx
@@ -5,9 +5,13 @@ sdk_version: "4.x"
 description: "CometChat Calling SDK v4 - Legacy Release - Overview for Flutter. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
-<Note>
-🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/flutter/overview)
-</Note>
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/flutter/presenter-mode.mdx
+++ b/calls/v4/flutter/presenter-mode.mdx
@@ -2,8 +2,16 @@
 title: "Presenter Mode"
 sidebarTitle: "Presenter Mode"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Presenter Mode for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Presenter Mode for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/flutter/recording.mdx
+++ b/calls/v4/flutter/recording.mdx
@@ -2,8 +2,16 @@
 title: "Recording"
 sidebarTitle: "Recording"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Recording for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Recording for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 This section will guide you to implement call recording feature for the voice and video calls.
 

--- a/calls/v4/flutter/ringing.mdx
+++ b/calls/v4/flutter/ringing.mdx
@@ -2,8 +2,16 @@
 title: "Ringing"
 sidebarTitle: "Ringing"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Ringing for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Ringing for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/flutter/session-timeout.mdx
+++ b/calls/v4/flutter/session-timeout.mdx
@@ -2,8 +2,16 @@
 title: "Session Timeout Flow"
 sidebarTitle: "Session Timeout"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Session Timeout for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Session Timeout for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 Available since v4.1.0
 

--- a/calls/v4/flutter/setup.mdx
+++ b/calls/v4/flutter/setup.mdx
@@ -2,8 +2,16 @@
 title: "Setup"
 sidebarTitle: "Setup"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Setup for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Setup for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 ### Get your Application Keys
 

--- a/calls/v4/flutter/standalone-calling.mdx
+++ b/calls/v4/flutter/standalone-calling.mdx
@@ -2,8 +2,16 @@
 title: "Standalone Calling"
 sidebarTitle: "Standalone Calling"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Standalone Calling for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Standalone Calling for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/flutter/video-view-customisation.mdx
+++ b/calls/v4/flutter/video-view-customisation.mdx
@@ -2,8 +2,16 @@
 title: "Video View Customisation"
 sidebarTitle: "Video View Customisation"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Video View Customisation for Flutter"
+description: "CometChat Calling SDK v4 - Legacy Release - Video View Customisation for Flutter"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (Flutter).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/flutter/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/flutter/migration-guide-v5).
+</Warning>
 
 This section will guide you to customise the main video container.
 

--- a/calls/v4/ios/call-logs.mdx
+++ b/calls/v4/ios/call-logs.mdx
@@ -2,8 +2,16 @@
 title: "Call Logs"
 sidebarTitle: "Call Logs"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Logs for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Logs for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/ios/call-session.mdx
+++ b/calls/v4/ios/call-session.mdx
@@ -2,8 +2,16 @@
 title: "Call Session"
 sidebarTitle: "Call Session"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Session for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Session for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/ios/launch-call-screen-on-tap-of-push-notification.mdx
+++ b/calls/v4/ios/launch-call-screen-on-tap-of-push-notification.mdx
@@ -2,8 +2,16 @@
 title: "Launch Call Screen On Tap Of Push Notification"
 sidebarTitle: "Launch Call Screen On Push"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Launch Call Screen On Tap Of Push Notification for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Launch Call Screen On Tap Of Push Notification for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 <Frame>
   <img src="/images/2d5bad5a-1623200474-c7b9fd90f64ad8d19c5240085fa241fd.jpg" />

--- a/calls/v4/ios/overview.mdx
+++ b/calls/v4/ios/overview.mdx
@@ -2,11 +2,11 @@
 title: "Calling SDK"
 sidebarTitle: "Overview"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Overview for iOS. This is the stable v4 documentation. Most users should use this version."
+description: "CometChat Calling SDK v4 - Legacy Release - Overview for iOS. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
 <Note>
-🚀 **v5 Beta Available** — The Calling SDK v5 is now available in beta with significant improvements. [Check out the v5 docs →](/calls/ios/overview)
+🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/ios/overview)
 </Note>
 
 ## Overview

--- a/calls/v4/ios/overview.mdx
+++ b/calls/v4/ios/overview.mdx
@@ -5,9 +5,13 @@ sdk_version: "4.x"
 description: "CometChat Calling SDK v4 - Legacy Release - Overview for iOS. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
-<Note>
-🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/ios/overview)
-</Note>
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/ios/presenter-mode.mdx
+++ b/calls/v4/ios/presenter-mode.mdx
@@ -2,8 +2,16 @@
 title: "Presenter Mode"
 sidebarTitle: "Presenter Mode"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Presenter Mode for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Presenter Mode for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/ios/recording.mdx
+++ b/calls/v4/ios/recording.mdx
@@ -2,8 +2,16 @@
 title: "Recording"
 sidebarTitle: "Recording"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Recording for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Recording for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 This section will guide you to implement call recording feature for the voice and video calls.
 

--- a/calls/v4/ios/ringing.mdx
+++ b/calls/v4/ios/ringing.mdx
@@ -2,8 +2,16 @@
 title: "Ringing"
 sidebarTitle: "Ringing"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Ringing for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Ringing for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/ios/session-timeout.mdx
+++ b/calls/v4/ios/session-timeout.mdx
@@ -2,8 +2,16 @@
 title: "Session Timeout Flow"
 sidebarTitle: "Session Timeout"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Session Timeout for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Session Timeout for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 Available since v4.1.1
 

--- a/calls/v4/ios/setup.mdx
+++ b/calls/v4/ios/setup.mdx
@@ -2,8 +2,16 @@
 title: "Setup"
 sidebarTitle: "Setup"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Setup for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Setup for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 The **CometChatCalls** is developed to keep developers in mind and aims to reduce development efforts significantly. Let's start to integrate Calls Kit into your project.
 

--- a/calls/v4/ios/standalone-calling.mdx
+++ b/calls/v4/ios/standalone-calling.mdx
@@ -2,8 +2,16 @@
 title: "Standalone Calling"
 sidebarTitle: "Standalone Calling"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Standalone Calling for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Standalone Calling for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/ios/video-view-customisation.mdx
+++ b/calls/v4/ios/video-view-customisation.mdx
@@ -2,8 +2,16 @@
 title: "Video View Customisation"
 sidebarTitle: "Video View Customisation"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Video View Customisation for iOS"
+description: "CometChat Calling SDK v4 - Legacy Release - Video View Customisation for iOS"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (iOS).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/ios/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/ios/migration-guide-v5).
+</Warning>
 
 This section will guide you to customise the main video container.
 

--- a/calls/v4/javascript/call-logs.mdx
+++ b/calls/v4/javascript/call-logs.mdx
@@ -2,8 +2,16 @@
 title: "Call Logs"
 sidebarTitle: "Call Logs"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Logs for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Logs for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/javascript/call-session.mdx
+++ b/calls/v4/javascript/call-session.mdx
@@ -2,8 +2,16 @@
 title: "Call Session"
 sidebarTitle: "Call Session"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Session for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Session for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/javascript/custom-css.mdx
+++ b/calls/v4/javascript/custom-css.mdx
@@ -2,8 +2,16 @@
 title: "Custom CSS"
 sidebarTitle: "Custom CSS"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Custom CSS for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Custom CSS for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 Passing custom CSS allows you to personalize and enhance the user interface of the call screen.
 

--- a/calls/v4/javascript/overview.mdx
+++ b/calls/v4/javascript/overview.mdx
@@ -2,11 +2,11 @@
 title: "Calling SDK"
 sidebarTitle: "Overview"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Overview for JavaScript. This is the stable v4 documentation. Most users should use this version."
+description: "CometChat Calling SDK v4 - Legacy Release - Overview for JavaScript. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
 <Note>
-🚀 **v5 Beta Available** — The Calling SDK v5 is now available in beta with significant improvements. [Check out the v5 docs →](/calls/javascript/overview)
+🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/javascript/overview)
 </Note>
 
 ## Overview

--- a/calls/v4/javascript/overview.mdx
+++ b/calls/v4/javascript/overview.mdx
@@ -5,9 +5,13 @@ sdk_version: "4.x"
 description: "CometChat Calling SDK v4 - Legacy Release - Overview for JavaScript. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
-<Note>
-🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/javascript/overview)
-</Note>
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/javascript/presenter-mode.mdx
+++ b/calls/v4/javascript/presenter-mode.mdx
@@ -2,8 +2,16 @@
 title: "Presenter Mode"
 sidebarTitle: "Presenter Mode"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Presenter Mode for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Presenter Mode for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/javascript/recording.mdx
+++ b/calls/v4/javascript/recording.mdx
@@ -2,8 +2,16 @@
 title: "Recording (Beta)"
 sidebarTitle: "Recording"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Recording for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Recording for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 This section will guide you to implement call recording feature for the voice and video calls.
 

--- a/calls/v4/javascript/ringing.mdx
+++ b/calls/v4/javascript/ringing.mdx
@@ -2,8 +2,16 @@
 title: "Ringing"
 sidebarTitle: "Ringing"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Ringing for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Ringing for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/javascript/session-timeout.mdx
+++ b/calls/v4/javascript/session-timeout.mdx
@@ -2,8 +2,16 @@
 title: "Session Timeout Flow"
 sidebarTitle: "Session Timeout"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Session Timeout for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Session Timeout for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 Available since v4.1.0
 

--- a/calls/v4/javascript/setup.mdx
+++ b/calls/v4/javascript/setup.mdx
@@ -2,8 +2,16 @@
 title: "Setup"
 sidebarTitle: "Setup"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Setup for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Setup for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 ## Get your Application Keys
 

--- a/calls/v4/javascript/standalone-calling.mdx
+++ b/calls/v4/javascript/standalone-calling.mdx
@@ -2,8 +2,16 @@
 title: "Standalone Calling"
 sidebarTitle: "Standalone Calling"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Standalone Calling for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Standalone Calling for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/javascript/video-view-customisation.mdx
+++ b/calls/v4/javascript/video-view-customisation.mdx
@@ -2,8 +2,16 @@
 title: "Video View Customisation"
 sidebarTitle: "Video View Customisation"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Video View Customisation for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Video View Customisation for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference**

--- a/calls/v4/javascript/virtual-background.mdx
+++ b/calls/v4/javascript/virtual-background.mdx
@@ -2,8 +2,16 @@
 title: "Virtual Background"
 sidebarTitle: "Virtual Background"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Virtual Background for JavaScript"
+description: "CometChat Calling SDK v4 - Legacy Release - Virtual Background for JavaScript"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (JavaScript).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/javascript/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/javascript/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference**

--- a/calls/v4/react-native/call-logs.mdx
+++ b/calls/v4/react-native/call-logs.mdx
@@ -2,8 +2,16 @@
 title: "Call Logs"
 sidebarTitle: "Call Logs"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Logs for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Logs for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Fetch call logs:

--- a/calls/v4/react-native/call-session.mdx
+++ b/calls/v4/react-native/call-session.mdx
@@ -2,8 +2,16 @@
 title: "Call Session"
 sidebarTitle: "Call Session"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Call Session for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Call Session for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Generate token and start a call session:

--- a/calls/v4/react-native/expo-integration-guide.mdx
+++ b/calls/v4/react-native/expo-integration-guide.mdx
@@ -2,8 +2,16 @@
 title: "Expo Integration"
 sidebarTitle: "Expo Integration"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Expo Integration Guide for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Expo Integration Guide for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Key Expo setup steps:

--- a/calls/v4/react-native/overview.mdx
+++ b/calls/v4/react-native/overview.mdx
@@ -2,11 +2,11 @@
 title: "Calling SDK"
 sidebarTitle: "Overview"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Overview for React Native. This is the stable v4 documentation. Most users should use this version."
+description: "CometChat Calling SDK v4 - Legacy Release - Overview for React Native. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
 <Note>
-🚀 **v5 Beta Available** — The Calling SDK v5 is now available in beta with significant improvements. [Check out the v5 docs →](/calls/react-native/overview)
+🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/react-native/overview)
 </Note>
 
 ## Overview

--- a/calls/v4/react-native/overview.mdx
+++ b/calls/v4/react-native/overview.mdx
@@ -5,9 +5,13 @@ sdk_version: "4.x"
 description: "CometChat Calling SDK v4 - Legacy Release - Overview for React Native. This is the legacy v4 documentation. Most users should use v5, the current stable version."
 ---
 
-<Note>
-🚀 **CometChat Calling SDK v5 is now available!** It is the current stable version, with significant improvements over v4. [Switch to v5 →](/calls/react-native/overview)
-</Note>
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 ## Overview
 

--- a/calls/v4/react-native/presenter-mode.mdx
+++ b/calls/v4/react-native/presenter-mode.mdx
@@ -2,8 +2,16 @@
 title: "Presenter Mode"
 sidebarTitle: "Presenter Mode"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Presenter Mode for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Presenter Mode for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Start a presentation session:

--- a/calls/v4/react-native/recording.mdx
+++ b/calls/v4/react-native/recording.mdx
@@ -2,8 +2,16 @@
 title: "Recording (Beta)"
 sidebarTitle: "Recording"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Recording for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Recording for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Start and stop call recording:

--- a/calls/v4/react-native/ringing.mdx
+++ b/calls/v4/react-native/ringing.mdx
@@ -2,8 +2,16 @@
 title: "Ringing"
 sidebarTitle: "Ringing"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Ringing for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Ringing for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Initiate a call and listen for events:

--- a/calls/v4/react-native/session-timeout.mdx
+++ b/calls/v4/react-native/session-timeout.mdx
@@ -2,8 +2,16 @@
 title: "Session Timeout Flow"
 sidebarTitle: "Session Timeout"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Session Timeout for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Session Timeout for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 Available since v4.2.0
 

--- a/calls/v4/react-native/setup.mdx
+++ b/calls/v4/react-native/setup.mdx
@@ -2,8 +2,16 @@
 title: "Setup"
 sidebarTitle: "Setup"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Setup for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Setup for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Install and initialize the Calls SDK:

--- a/calls/v4/react-native/standalone-calling.mdx
+++ b/calls/v4/react-native/standalone-calling.mdx
@@ -2,8 +2,16 @@
 title: "Standalone Calling"
 sidebarTitle: "Standalone Calling"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Standalone Calling for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Standalone Calling for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Generate token and start a standalone call session:

--- a/calls/v4/react-native/video-view-customisation.mdx
+++ b/calls/v4/react-native/video-view-customisation.mdx
@@ -2,8 +2,16 @@
 title: "Video View Customisation"
 sidebarTitle: "Video View Customisation"
 sdk_version: "4.x"
-description: "CometChat Calling SDK v4 - Stable Release - Video View Customisation for React Native"
+description: "CometChat Calling SDK v4 - Legacy Release - Video View Customisation for React Native"
 ---
+
+<Warning>
+**You're reading the legacy documentation for Calling SDK v4 (React Native).**
+
+Follow this page only if your app is on **v4.x**. If you're using v5, see the [**Calling SDK v5 documentation**](/calls/react-native/overview) instead.
+
+Ready to move off v4? Follow the [v4 → v5 migration guide](/calls/react-native/migration-guide-v5).
+</Warning>
 
 <Info>
 **Quick Reference** - Customize the main video container:


### PR DESCRIPTION
## Description

This PR brings the Calls SDK docs in line with the v5 release and fills in behaviours that developers were previously hitting only at runtime.

There are two parts:

### 1. v4 docs are now clearly marked as legacy

v5 is the current stable release, but the v4 pages still described themselves as "Stable Release" and only carried a small "v5 Beta Available" note. That's misleading for anyone landing on a v4 page from search.

- Every v4 page (54 files across Android, iOS, Flutter, JavaScript, React Native) now has a `<Warning>` banner at the top stating it's legacy documentation, with links to the equivalent v5 page and to the v4 → v5 migration guide for that platform.
- Frontmatter `description` fields changed from "Stable Release" to "Legacy Release" so search results and previews say the right thing too.
- The overview pages' old "🚀 v5 Beta Available" `<Note>` is replaced by the same `<Warning>`, since v5 is no longer in beta.

### 2. Newly documented v5 behaviours

Gaps that were causing confusion, added to the v5 pages:

- **Recording lifecycle** (`android`, `ios`, `flutter`, `javascript`, `react-native`) — a recording keeps running until it's stopped, whether started manually or via auto-start. Documents the two automatic stop conditions: ~1 minute after everyone leaves, or after 10 minutes with everyone muted.

- **Single active session** (`javascript`, `react-native`) — `CometChatCalls` is a singleton holding one session at a time. New "Single Active Session" section on the overview pages explaining why `leaveSession()` and the other actions take no session ID, plus the correct leave → wait for `onSessionLeft` → join pattern for switching calls. Cross-referenced from `join-session` and `actions`. The RN version adds that only one `CometChatCalls.Component` should be mounted at a time.

- **Mute/pause are now paired methods** (JS + RN migration guides) — v4's `muteAudio(true/false)` became `muteAudio()` / `unmuteAudio()`, and `pauseVideo(true/false)` became `pauseVideo()` / `resumeVideo()`. This was easy to miss in the rename table, so it now has a callout and a before/after snippet.

- **v5 events need `addEventListener()`** (JS + RN migration guides) — new events like `onSessionJoined`, `onConnectionLost`, and `onCallLayoutChanged` never fire through the v4 registration paths (`setCallEventListener()`, `addCallEventListener()`), because `OngoingCallListener` only carries the legacy event set. Also clarifies that migration can be incremental — `addEventListener()` coexists with an existing v4 listener.

- **React Native New Architecture** (`react-native/setup`) — new section confirming the SDK works on both the old architecture and the New Architecture including bridgeless mode, with no extra setup. Notes that it ships as a legacy native module running through RN's interop layer, so behaviour is identical either way. The prerequisites list on the overview now links to it.

## Related Issue(s)

<!-- Please link to any related issue(s) here using the GitHub issue linking syntax: #issue-number -->

## Type of Change

- [x] Documentation correction/update
- [ ] New documentation
- [x] Improvement to existing documentation
- [ ] Typo fix
- [ ] Other (please specify)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My branch name follows the [naming convention](.github/branch-naming-convention.md)
- [x] My changes follow the documentation style guide
- [x] I have checked for spelling and grammar errors
- [x] All links in my changes are valid and working
- [x] My changes are accurately described in this pull request

## Additional Information

- Content-only changes — no navigation (`docs.json`), redirect, or config changes, so no v4 URLs move or break.
- Single-active-session and mute/pause notes are scoped to JavaScript and React Native, since those are the platforms where the v5 docs currently cover these APIs. Recording auto-stop is applied to all five platforms.
- Worth a check from the SDK team on two specifics: the recording auto-stop timings (~1 min after everyone leaves, 10 min all-muted), and that the RN interop-layer description matches how the module is actually packaged.

## Screenshots (if applicable)

<!-- If your changes include visual elements, please add screenshots to help explain your changes -->
