### PR TITLE
docs(notifications): subscribed-threads & quoted-reply preference options

### DIFF
--- a/notifications/preferences.mdx
+++ b/notifications/preferences.mdx
@@ -47,8 +47,8 @@ As the name suggests, these preferences help you to configure Notifications for 
 | Categories      | Events                      | Available preferences                                                                                                        | Can user override?       |
 | --------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | Conversations   | New messages                | • Don't notify<br/>• **Notify for all messages (Default)** <br/>• Notify for messages with mentions                                   | • **Yes (Default)**<br/>• No |
-|                 | New replies                 | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions                                     | • **Yes (Default)**<br/>• No |
-|                 | New quoted replies          | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions                                     | • **Yes (Default)**<br/>• No |
+|                 | New replies                 | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions<br/>• Notify for subscribed threads                                     | • **Yes (Default)**<br/>• No |
+|                 | New quoted replies          | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions<br/>• Notify when my message is quoted                                     | • **Yes (Default)**<br/>• No |
 | Message actions | Message is edited           | • Don't notify<br/>• **Notify (Default)**                                                                                        | • Yes<br/>• **No (Default)** |
 |                 | Message is deleted          | • Don't notify<br/>• **Notify (Default)**                                                                                        | • Yes<br/>• **No (Default)** |
 |                 | Message receives a reaction | • Don't notify<br/>• Notify for reactions received on all messages<br/>• **Notify for reactions received on own messages (Default)** | • **Yes (Default)**<br/>• No |
@@ -59,6 +59,15 @@ As the name suggests, these preferences help you to configure Notifications for 
 |                 | A member is banned          | • **Don't notify (Default)**<br/>• Notify                                                                                        | • **Yes (Default)**<br/>• No |
 |                 | A member is unbanned        | • **Don't notify (Default)**<br/>• Notify                                                                                        | • **Yes (Default)**<br/>• No |
 |                 | A member's scope changes    | • **Don't notify (Default)**<br/>• Notify                                                                                        | • **Yes (Default)**<br/>• No |
+
+<Info>
+**Reply notification options**
+
+- **Notify for subscribed threads** — the user is notified about new replies only in threads they are *subscribed* to. A user becomes subscribed to a thread when they start it (send the parent message), reply in it, are @-mentioned in it, or explicitly follow it — and can unfollow to stop. Useful in busy conversations where users only want updates on threads they are part of.
+- **Notify when my message is quoted** *(quoted replies only)* — the sender of the original message is notified whenever someone quote-replies (swipe-to-reply) to their message, independent of threads or mentions.
+
+Both options apply to **group** and **one-on-one** conversations, across **push, email, and SMS**.
+</Info>
 
 <Note>
 Regarding Message edited & Message deleted events
@@ -358,8 +367,8 @@ As the name suggests, these preferences help you to configure Notifications for 
 | Categories      | Events                      | Available preferences                                                                                                        | Can user override?       |
 | --------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
 | Conversations   | New messages                | • Don't notify<br/>• **Notify for all messages (Default)**<br/>• Notify for messages with mentions                                   | • **Yes (Default)**<br/>• No |
-|                 | New replies                 | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions                                     | • **Yes (Default)**<br/>• No |
-|                 | New quoted replies          | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions                                     | • **Yes (Default)**<br/>• No |
+|                 | New replies                 | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions<br/>• Notify for subscribed threads                                     | • **Yes (Default)**<br/>• No |
+|                 | New quoted replies          | • Don't notify<br/>• **Notify for all replies (Default)**<br/>• Notify for replies with mentions<br/>• Notify when my message is quoted                                     | • **Yes (Default)**<br/>• No |
 | Message actions | Message is edited           | • Don't notify<br/>• **Notify (Default)**                                                                                        | • Yes<br/>• **No (Default)** |
 |                 | Message is deleted          | • Don't notify<br/>• **Notify (Default)**                                                                                        | • Yes<br/>• **No (Default)** |
 |                 | Message receives a reaction | • Don't notify<br/>• Notify for reactions received on all messages<br/>• **Notify for reactions received on own messages (Default)** | • **Yes (Default)**<br/>• No |

--- a/notifications/preferences.mdx
+++ b/notifications/preferences.mdx
@@ -61,12 +61,12 @@ As the name suggests, these preferences help you to configure Notifications for 
 |                 | A member's scope changes    | • **Don't notify (Default)**<br/>• Notify                                                                                        | • **Yes (Default)**<br/>• No |
 
 <Info>
-**About the two reply options**
+**Reply notification options**
 
-- **Notify for subscribed threads** — the user is notified only about replies in threads they have *subscribed* to, so busy conversations stay quiet and people hear only about the threads they are part of. A user is subscribed automatically when they start a thread, reply in it, or are @-mentioned in it, and can also subscribe or unsubscribe to any thread manually.
-- **Notify when my message is quoted** *(quoted replies only)* — the user is notified whenever someone quote-replies (swipe-to-reply) to a message they sent, even when it is not in a subscribed thread and does not @-mention them.
+- **Notify for subscribed threads** — the user is notified about new replies only in threads they are *subscribed* to. A user becomes subscribed to a thread by sending its parent message, replying in it, being @-mentioned in it, or explicitly following it — and can unfollow to stop. Useful in busy conversations where users only want updates on threads they are part of.
+- **Notify when my message is quoted** *(quoted replies only)* — the sender of the original message is notified whenever someone quote-replies (swipe-to-reply) to their message, independent of threads or mentions.
 
-Both options are available for **group** and **one-on-one** conversations and work across **push, email, and SMS**.
+Both options apply to **group** and **one-on-one** conversations, across **push, email, and SMS**.
 </Info>
 
 <Note>

--- a/notifications/preferences.mdx
+++ b/notifications/preferences.mdx
@@ -61,12 +61,12 @@ As the name suggests, these preferences help you to configure Notifications for 
 |                 | A member's scope changes    | • **Don't notify (Default)**<br/>• Notify                                                                                        | • **Yes (Default)**<br/>• No |
 
 <Info>
-**Reply notification options**
+**About the two reply options**
 
-- **Notify for subscribed threads** — the user is notified about new replies only in threads they are *subscribed* to. A user becomes subscribed to a thread when they start it (send the parent message), reply in it, are @-mentioned in it, or explicitly follow it — and can unfollow to stop. Useful in busy conversations where users only want updates on threads they are part of.
-- **Notify when my message is quoted** *(quoted replies only)* — the sender of the original message is notified whenever someone quote-replies (swipe-to-reply) to their message, independent of threads or mentions.
+- **Notify for subscribed threads** — the user is notified only about replies in threads they have *subscribed* to, so busy conversations stay quiet and people hear only about the threads they are part of. A user is subscribed automatically when they start a thread, reply in it, or are @-mentioned in it, and can also subscribe or unsubscribe to any thread manually.
+- **Notify when my message is quoted** *(quoted replies only)* — the user is notified whenever someone quote-replies (swipe-to-reply) to a message they sent, even when it is not in a subscribed thread and does not @-mention them.
 
-Both options apply to **group** and **one-on-one** conversations, across **push, email, and SMS**.
+Both options are available for **group** and **one-on-one** conversations and work across **push, email, and SMS**.
 </Info>
 
 <Note>


### PR DESCRIPTION
Documents two new notification **reply** preference options on the Preferences page (dashboard configuration). Notifications-only — SDK docs are out of scope (frontend team).

## Changes (`notifications/preferences.mdx`)
- **New replies** row (group + one-on-one tables) → adds **"Notify for subscribed threads"** (thread-subscription feature, ENG-36882).
- **New quoted replies** row (group + one-on-one) → adds **"Notify when my message is quoted"** (ENG-38091).
- Explainer callout: what "subscribed to a thread" means (start / reply / @-mention / explicit follow + unfollow), who's notified on a quote (the original sender), and that both apply to group + 1-1 across push / email / SMS.

## Intentionally not touched
- **SDK code samples** on the page — the SDK enums don't carry the new values yet; that's the frontend team's update. The new options live under "Dashboard configuration," so there's no false SDK implication.
- `email-preferences.mdx` / `sms-preferences.mdx` — they don't contain the option tables (those live only in `preferences.mdx`).